### PR TITLE
 FIX: Loading state persists after bad card entered

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,5 @@
+AllCops:
+  Exclude:
+    - 'gems/**/*'
 inherit_gem:
   rubocop-discourse: default.yml

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,6 +5,7 @@ GIT
     translations-manager (0.6)
 
 GEM
+  remote: https://rubygems.org/
   specs:
     ast (2.4.1)
     parallel (1.19.2)

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -25,6 +25,7 @@ export default Controller.extend({
   createSubscription(plan) {
     return this.stripe.createToken(this.get("cardElement")).then((result) => {
       if (result.error) {
+        this.set("loading", false);
         return result;
       } else {
         const customer = Customer.create({ source: result.token.id });

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -9,6 +9,9 @@ en:
     errors:
       discourse_patrons_amount_must_be_currency: "Currency amounts must be currencies without dollar symbol (eg 1.50)"
   js:
+    filters:
+      subscribe:
+        help: Support this site by subscribing
     discourse_subscriptions:
       title: Discourse Subscriptions
       admin_navigation: Subscriptions


### PR DESCRIPTION
If a bad card number was entered and the subscribe button clicked, the
subscription button still disappeared and subscribing was not possible
without refreshing the page.

Also adds a missing tooltip too.