### PR TITLE
FEATURE: Better UX for anonymous users

### DIFF
--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -5,7 +5,7 @@ module DiscourseSubscriptions
     include DiscourseSubscriptions::Stripe
     include DiscourseSubscriptions::Group
     before_action :set_api_key
-    requires_login
+    requires_login except: [:index, :show]
 
     def index
       begin

--- a/assets/javascripts/discourse/components/login-required.js.es6
+++ b/assets/javascripts/discourse/components/login-required.js.es6
@@ -1,12 +1,13 @@
 import Component from "@ember/component";
 import cookie from "discourse/lib/cookie";
 import DiscourseURL from "discourse/lib/url";
+import getURL from "discourse-common/lib/get-url";
 
 export default Component.extend({
   classNames: ["login-required", "subscriptions"],
   actions: {
     createAccount() {
-      const destinationUrl = document.baseURI;
+      const destinationUrl = getURL(document.baseURI);
       cookie("destination_url", destinationUrl, { path: "/" });
       DiscourseURL.redirectTo("/login");
     },

--- a/assets/javascripts/discourse/components/login-required.js.es6
+++ b/assets/javascripts/discourse/components/login-required.js.es6
@@ -1,17 +1,19 @@
 import Component from "@ember/component";
 import cookie from "discourse/lib/cookie";
 import DiscourseURL from "discourse/lib/url";
+import {
+  default as getURL,
+  getAbsoluteURL,
+} from "discourse-common/lib/get-url";
 
 export default Component.extend({
   classNames: ["login-required", "subscriptions"],
   actions: {
     createAccount() {
-      const destinationUrl = document.baseURI;
+      const destinationUrl = getAbsoluteURL(window.location.pathname);
+      const cookiePath = getURL("/");
 
-      const pathRegEx = /(\/\w*)\/s.*$/g;
-      const [pathMatch] = destinationUrl.matchAll(pathRegEx);
-      const path = pathMatch ? pathMatch[1] : "/";
-      cookie("destination_url", destinationUrl, { path: path });
+      cookie("destination_url", destinationUrl, { path: cookiePath });
       DiscourseURL.redirectTo("/login");
     },
   },

--- a/assets/javascripts/discourse/components/login-required.js.es6
+++ b/assets/javascripts/discourse/components/login-required.js.es6
@@ -1,14 +1,17 @@
 import Component from "@ember/component";
 import cookie from "discourse/lib/cookie";
 import DiscourseURL from "discourse/lib/url";
-import getURL from "discourse-common/lib/get-url";
 
 export default Component.extend({
   classNames: ["login-required", "subscriptions"],
   actions: {
     createAccount() {
-      const destinationUrl = getURL(document.baseURI);
-      cookie("destination_url", destinationUrl, { path: "/" });
+      const destinationUrl = document.baseURI;
+
+      const pathRegEx = /(\/\w*)\/s.*$/g;
+      const [pathMatch] = destinationUrl.matchAll(pathRegEx);
+      const path = pathMatch ? pathMatch[1] : "/";
+      cookie("destination_url", destinationUrl, { path: path });
       DiscourseURL.redirectTo("/login");
     },
   },

--- a/assets/javascripts/discourse/components/login-required.js.es6
+++ b/assets/javascripts/discourse/components/login-required.js.es6
@@ -1,16 +1,13 @@
 import Component from "@ember/component";
 import cookie from "discourse/lib/cookie";
 import DiscourseURL from "discourse/lib/url";
-import {
-  default as getURL,
-  getAbsoluteURL,
-} from "discourse-common/lib/get-url";
+import { default as getURL } from "discourse-common/lib/get-url";
 
 export default Component.extend({
   classNames: ["login-required", "subscriptions"],
   actions: {
     createAccount() {
-      const destinationUrl = getAbsoluteURL(window.location.pathname);
+      const destinationUrl = window.location.href;
       const cookiePath = getURL("/");
 
       cookie("destination_url", destinationUrl, { path: cookiePath });

--- a/assets/javascripts/discourse/components/login-required.js.es6
+++ b/assets/javascripts/discourse/components/login-required.js.es6
@@ -1,0 +1,14 @@
+import Component from "@ember/component";
+import cookie from "discourse/lib/cookie";
+import DiscourseURL from "discourse/lib/url";
+
+export default Component.extend({
+  classNames: ["login-required", "subscriptions"],
+  actions: {
+    createAccount() {
+      const destinationUrl = document.baseURI;
+      cookie("destination_url", destinationUrl, { path: "/" });
+      DiscourseURL.redirectTo("/login");
+    },
+  },
+});

--- a/assets/javascripts/discourse/components/product-list.js.es6
+++ b/assets/javascripts/discourse/components/product-list.js.es6
@@ -1,17 +1,12 @@
 import discourseComputed from "discourse-common/utils/decorators";
-import User from "discourse/models/user";
 import { isEmpty } from "@ember/utils";
 import Component from "@ember/component";
 
 export default Component.extend({
   classNames: ["product-list"],
+
   @discourseComputed("products")
   emptyProducts(products) {
     return isEmpty(products);
-  },
-
-  @discourseComputed()
-  isLoggedIn() {
-    return User.current();
   },
 });

--- a/assets/javascripts/discourse/controllers/s-index.js.es6
+++ b/assets/javascripts/discourse/controllers/s-index.js.es6
@@ -1,20 +1,10 @@
 import Controller from "@ember/controller";
 import discourseComputed from "discourse-common/utils/decorators";
 import User from "discourse/models/user";
-import cookie from "discourse/lib/cookie";
-import DiscourseURL from "discourse/lib/url";
 
 export default Controller.extend({
   @discourseComputed()
   isLoggedIn() {
     return User.current();
-  },
-
-  actions: {
-    createAccount() {
-      const destinationUrl = document.baseURI;
-      cookie("destination_url", destinationUrl, { path: "/" });
-      DiscourseURL.redirectTo("/login");
-    },
   },
 });

--- a/assets/javascripts/discourse/controllers/s-index.js.es6
+++ b/assets/javascripts/discourse/controllers/s-index.js.es6
@@ -1,3 +1,20 @@
 import Controller from "@ember/controller";
+import discourseComputed from "discourse-common/utils/decorators";
+import User from "discourse/models/user";
+import cookie from "discourse/lib/cookie";
+import DiscourseURL from "discourse/lib/url";
 
-export default Controller.extend({});
+export default Controller.extend({
+  @discourseComputed()
+  isLoggedIn() {
+    return User.current();
+  },
+
+  actions: {
+    createAccount() {
+      const destinationUrl = document.baseURI;
+      cookie("destination_url", destinationUrl, { path: "/" });
+      DiscourseURL.redirectTo("/login");
+    },
+  },
+});

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -2,6 +2,8 @@ import Controller from "@ember/controller";
 import Subscription from "discourse/plugins/discourse-subscriptions/discourse/models/subscription";
 import Transaction from "discourse/plugins/discourse-subscriptions/discourse/models/transaction";
 import I18n from "I18n";
+import discourseComputed from "discourse-common/utils/decorators";
+import User from "discourse/models/user";
 
 export default Controller.extend({
   selectedPlan: null,
@@ -19,6 +21,11 @@ export default Controller.extend({
 
   alert(path) {
     bootbox.alert(I18n.t(`discourse_subscriptions.${path}`));
+  },
+
+  @discourseComputed()
+  isAnonymous() {
+    return !User.current();
   },
 
   createSubscription(plan) {

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -2,11 +2,10 @@ import Controller from "@ember/controller";
 import Subscription from "discourse/plugins/discourse-subscriptions/discourse/models/subscription";
 import Transaction from "discourse/plugins/discourse-subscriptions/discourse/models/transaction";
 import I18n from "I18n";
-import discourseComputed from "discourse-common/utils/decorators";
-import User from "discourse/models/user";
 
 export default Controller.extend({
   selectedPlan: null,
+  isAnonymous: Ember.computed.not("currentUser"),
 
   init() {
     this._super(...arguments);
@@ -21,11 +20,6 @@ export default Controller.extend({
 
   alert(path) {
     bootbox.alert(I18n.t(`discourse_subscriptions.${path}`));
-  },
-
-  @discourseComputed()
-  isAnonymous() {
-    return !User.current();
   },
 
   createSubscription(plan) {

--- a/assets/javascripts/discourse/routes/s-show.js.es6
+++ b/assets/javascripts/discourse/routes/s-show.js.es6
@@ -1,16 +1,9 @@
 import Route from "@ember/routing/route";
-import User from "discourse/models/user";
 import Product from "discourse/plugins/discourse-subscriptions/discourse/models/product";
 import Plan from "discourse/plugins/discourse-subscriptions/discourse/models/plan";
 import Subscription from "discourse/plugins/discourse-subscriptions/discourse/models/subscription";
-import DiscourseURL from "discourse/lib/url";
 
 export default Route.extend({
-  redirect() {
-    if (!User.current()) {
-      DiscourseURL.redirectTo("/s");
-    }
-  },
   model(params) {
     const product_id = params["subscription-id"];
 

--- a/assets/javascripts/discourse/routes/s-show.js.es6
+++ b/assets/javascripts/discourse/routes/s-show.js.es6
@@ -1,9 +1,16 @@
 import Route from "@ember/routing/route";
+import User from "discourse/models/user";
 import Product from "discourse/plugins/discourse-subscriptions/discourse/models/product";
 import Plan from "discourse/plugins/discourse-subscriptions/discourse/models/plan";
 import Subscription from "discourse/plugins/discourse-subscriptions/discourse/models/subscription";
+import DiscourseURL from "discourse/lib/url";
 
 export default Route.extend({
+  redirect() {
+    if (!User.current()) {
+      DiscourseURL.redirectTo("/s");
+    }
+  },
   model(params) {
     const product_id = params["subscription-id"];
 

--- a/assets/javascripts/discourse/templates/components/login-required.hbs
+++ b/assets/javascripts/discourse/templates/components/login-required.hbs
@@ -1,0 +1,2 @@
+<h3>{{i18n 'discourse_subscriptions.subscribe.unauthenticated'}}</h3>
+{{d-button label="log_in" action="createAccount" icon="user" class="btn btn-primary"}}

--- a/assets/javascripts/discourse/templates/components/product-list.hbs
+++ b/assets/javascripts/discourse/templates/components/product-list.hbs
@@ -13,7 +13,7 @@
         <div class="product-purchase">
           {{#if product.subscribed}}
             <span class="purchased">&#x2713; {{i18n 'discourse_subscriptions.subscribe.purchased'}}</span>
-            <a class="billing-link" href="/my/billing">{{I18n 'discourse_subscriptions.subscribe.go_to_billing'}}</a> 
+            <a class="billing-link" href="/my/billing">{{I18n 'discourse_subscriptions.subscribe.go_to_billing'}}</a>
           {{else}}
             {{#link-to "s.show" product.id disabled=product.subscribed class="btn btn-primary"}}
               {{i18n 'discourse_subscriptions.subscribe.title'}}
@@ -24,9 +24,4 @@
     </div>
   {{/each}}
 
-  {{#unless isLoggedIn}}
-    <p>
-      {{i18n 'discourse_subscriptions.subscribe.unauthenticated'}}
-    </p>
-  {{/unless}}
 {{/if}}

--- a/assets/javascripts/discourse/templates/s/index.hbs
+++ b/assets/javascripts/discourse/templates/s/index.hbs
@@ -1,5 +1,4 @@
 {{#unless isLoggedIn}}
-  <h3>{{i18n 'discourse_subscriptions.subscribe.unauthenticated'}}</h3>
-  {{d-button label="log_in" action="createAccount" icon="user" class="btn btn-primary"}}
+  {{login-required}}
 {{/unless}}
 {{product-list products=model isLoggedIn=isLoggedIn}}

--- a/assets/javascripts/discourse/templates/s/index.hbs
+++ b/assets/javascripts/discourse/templates/s/index.hbs
@@ -1,1 +1,5 @@
-{{product-list products=model}}
+{{#unless isLoggedIn}}
+  <h3>{{i18n 'discourse_subscriptions.subscribe.unauthenticated'}}</h3>
+  {{d-button label="log_in" action="createAccount" icon="user" class="btn btn-primary"}}
+{{/unless}}
+{{product-list products=model isLoggedIn=isLoggedIn}}

--- a/assets/javascripts/discourse/templates/s/show.hbs
+++ b/assets/javascripts/discourse/templates/s/show.hbs
@@ -26,11 +26,13 @@
 
       <hr>
 
-      {{subscribe-card cardElement=cardElement}}
-
       {{#if loading}}
         {{loading-spinner}}
+      {{else if isAnonymous}}
+        {{login-required}}
       {{else}}
+        {{subscribe-card cardElement=cardElement}}
+
         {{d-button
           disabled=loading
           action="stripePaymentHandler"

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -63,7 +63,7 @@ en:
       subscribe:
         title: Subscribe
         no_products: There are currently no products available.
-        unauthenticated: You need to create an account to subscribe.
+        unauthenticated: Log in or create an account to subscribe.
         card:
           title: Payment
         customer:

--- a/test/javascripts/helpers/product-pretender.js.es6
+++ b/test/javascripts/helpers/product-pretender.js.es6
@@ -1,41 +1,46 @@
-export default function(helpers) {
+export default function (helpers) {
   const { response } = helpers;
 
-  this.get("/s/products", () => {
+  this.get("/s", () => {
     const products = [
       {
         id: "prod_23o8I7tU4g56",
         name: "Awesome Product",
         description:
-          "Subscribe to our awesome product. For only $230.10 per month, you can get access. This is a test site. No real credit card transactions."
+          "Subscribe to our awesome product. For only $230.10 per month, you can get access. This is a test site. No real credit card transactions.",
       },
       {
         id: "prod_B23dc9I7tU4eCy",
         name: "Special Product",
         description:
-          "This is another subscription product. You can have more than one. From $12 per month."
-      }
+          "This is another subscription product. You can have more than one. From $12 per month.",
+      },
     ];
 
     return response(products);
   });
 
-  this.get("/s/products/:id", () => {
-    const product = {};
-
-    return response(product);
-  });
-
-  this.get("/s/plans", () => {
+  this.get("/s/:id", () => {
+    const product = {
+      id: "prod_23o8I7tU4g56",
+      name: "Awesome Product",
+      description:
+        "Subscribe to our awesome product. For only $230.10 per month, you can get access. This is a test site. No real credit card transactions.",
+    };
     const plans = [
       {
         id: "plan_GHGHSHS8654G",
         amount: 200,
         currency: "usd",
-        interval: "month"
-      }
+        interval: "month",
+      },
     ];
 
-    return response(plans);
+    const model = {
+      product: product,
+      plans: plans,
+    };
+
+    return response(model);
   });
 }

--- a/test/javascripts/helpers/product-pretender.js.es6
+++ b/test/javascripts/helpers/product-pretender.js.es6
@@ -36,11 +36,6 @@ export default function (helpers) {
       },
     ];
 
-    const model = {
-      product: product,
-      plans: plans,
-    };
-
-    return response(model);
+    return response({ product, plans });
   });
 }


### PR DESCRIPTION
Previously we'd throw a 404 to anonymous users hitting the `/s/product_id` route, and not really give them anywhere to go on `/s`. This PR introduces a new flow:

- Browse to one of the pages
- Instead of being presented with a 404, see content now and instead get a login button
- Login writes the `destination_url` cookie to the current URL so that upon login, they're automatically redirected back
- PROFIT (literally)

I initially tried implementing this approach server-side only using the `redirect_to_login` method, it only stopped the model calls from the front end instead of directly redirecting to `/login`. I wasn't quite able to figure out this one. However, I think this is a better solution in the long run as it keeps the user in the checkout flow vs simply bouncing them to the login page on first fire.