### PR TITLE
FIX: Payments could not complete

### DIFF
--- a/assets/javascripts/discourse/templates/s/show.hbs
+++ b/assets/javascripts/discourse/templates/s/show.hbs
@@ -26,12 +26,13 @@
 
       <hr>
 
+      {{subscribe-card cardElement=cardElement}}
+
       {{#if loading}}
         {{loading-spinner}}
       {{else if isAnonymous}}
         {{login-required}}
       {{else}}
-        {{subscribe-card cardElement=cardElement}}
 
         {{d-button
           disabled=loading

--- a/assets/stylesheets/common/subscribe.scss
+++ b/assets/stylesheets/common/subscribe.scss
@@ -14,6 +14,10 @@
   width: 100%;
 }
 
+.anon #card-element {
+  display: none;
+}
+
 .StripeElement {
   box-sizing: border-box;
 


### PR DESCRIPTION
Due to putting the Stripe Elements HTML inside an if block in the
template, this caused state to be funky. As a result, calling
`this.stripe.createToken` failed to return a promise. Opted instead to
hide the elements via CSS for anonymous users to prevent this
showstopping bug.