### PR TITLE
FIX: Properly allow no group to be selected

### DIFF
--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-products-show-plans-show.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-products-show-plans-show.js.es6
@@ -1,22 +1,19 @@
 import discourseComputed from "discourse-common/utils/decorators";
 import DiscourseURL from "discourse/lib/url";
 import Controller from "@ember/controller";
+import { alias } from "@ember/object/computed";
 
 const RECURRING = "recurring";
 const ONE_TIME = "one_time";
 
 export default Controller.extend({
   // Also defined in settings.
-  selectedCurrency: Ember.computed.alias("model.plan.currency"),
-  selectedInterval: Ember.computed.alias("model.plan.interval"),
+  selectedCurrency: alias("model.plan.currency"),
+  selectedInterval: alias("model.plan.interval"),
 
   @discourseComputed("model.plan.metadata.group_name")
   selectedGroup(groupName) {
-    if (!groupName) {
-      return "no-group";
-    }
-
-    return groupName;
+    return groupName || "no-group";
   },
 
   @discourseComputed("model.groups")

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-products-show-plans-show.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-products-show-plans-show.js.es6
@@ -10,6 +10,26 @@ export default Controller.extend({
   selectedCurrency: Ember.computed.alias("model.plan.currency"),
   selectedInterval: Ember.computed.alias("model.plan.interval"),
 
+  @discourseComputed("model.plan.metadata.group_name")
+  selectedGroup(groupName) {
+    if (!groupName) {
+      return "no-group";
+    }
+
+    return groupName;
+  },
+
+  @discourseComputed("model.groups")
+  availableGroups(groups) {
+    return [
+      {
+        id: null,
+        name: "no-group",
+      },
+      ...groups,
+    ];
+  },
+
   @discourseComputed
   currencies() {
     return [
@@ -57,13 +77,9 @@ export default Controller.extend({
     },
 
     createPlan() {
-      // TODO: set default group name beforehand
-      if (this.get("model.plan.metadata.group_name") === undefined) {
-        this.set("model.plan.metadata", {
-          group_name: this.get("model.groups.firstObject.name"),
-        });
+      if (this.model.plan.metadata.group_name === "no-group") {
+        this.set("model.plan.metadata.group_name", null);
       }
-
       this.get("model.plan")
         .save()
         .then(() => this.redirect(this.productId))
@@ -73,6 +89,9 @@ export default Controller.extend({
     },
 
     updatePlan() {
+      if (this.model.plan.metadata.group_name === "no-group") {
+        this.set("model.plan.metadata.group_name", null);
+      }
       this.get("model.plan")
         .update()
         .then(() => this.redirect(this.productId))

--- a/assets/javascripts/discourse/routes/admin-plugins-discourse-subscriptions-products-show-plans-show.js.es6
+++ b/assets/javascripts/discourse/routes/admin-plugins-discourse-subscriptions-products-show-plans-show.js.es6
@@ -20,6 +20,9 @@ export default Route.extend({
         isRecurring: true,
         currency: Discourse.SiteSettings.discourse_subscriptions_currency,
         product: product.get("id"),
+        metadata: {
+          group_name: null,
+        },
       });
     } else {
       plan = AdminPlan.find(id).then((result) => {

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show-plans-show.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show-plans-show.hbs
@@ -15,10 +15,10 @@
   </p>
   <p>
     <label for="interval">{{i18n 'discourse_subscriptions.admin.plans.plan.group'}}</label>
-    {{combo-box 
+    {{combo-box
       valueProperty="name"
-      content=model.groups 
-      value=model.plan.metadata.group_name 
+      content=availableGroups
+      value=selectedGroup
       onChange=(action (mut model.plan.metadata.group_name))
     }}
     <div class="control-instructions">
@@ -30,10 +30,10 @@
     {{#if planFieldDisabled}}
       {{input class="plan-amount plan-currency" disabled=true value=model.plan.currency}}
     {{else}}
-      {{combo-box 
-        disabled=planFieldDisabled 
-        content=currencies 
-        value=model.plan.currency 
+      {{combo-box
+        disabled=planFieldDisabled
+        content=currencies
+        value=model.plan.currency
         onChange=(action (mut model.plan.currency))
       }}
     {{/if}}
@@ -44,16 +44,16 @@
       {{i18n 'discourse_subscriptions.admin.plans.plan.recurring'}}
     </label>
     {{#if planFieldDisabled}}
-      {{input 
-        type="checkbox" 
-        name="recurring" 
+      {{input
+        type="checkbox"
+        name="recurring"
         checked=model.plan.isRecurring
         disabled=true
       }}
     {{else}}
-      {{input 
-        type="checkbox" 
-        name="recurring" 
+      {{input
+        type="checkbox"
+        name="recurring"
         checked=model.plan.isRecurring
         change=(action 'changeRecurring')
       }}
@@ -67,10 +67,10 @@
       {{#if planFieldDisabled}}
         {{input disabled=true value=selectedInterval}}
       {{else}}
-        {{combo-box 
+        {{combo-box
           valueProperty="name"
-          content=availableIntervals 
-          value=selectedInterval 
+          content=availableIntervals
+          value=selectedInterval
           onChange=(action (mut selectedInterval))
         }}
       {{/if}}


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/subscriptions-group-shows-as-added-when-not-added-to-the-plan/169825

The group box was blank, but upon save, the very first group was selected. This is unexpected behavior for users.

Instead of this, I opted to use a no-group setting, which means users won't be added to a group when they subscribe if "no-group" is selected.