### PR TITLE
DEV: Transition from Ember constant to imports

### DIFF
--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -2,10 +2,11 @@ import Controller from "@ember/controller";
 import Subscription from "discourse/plugins/discourse-subscriptions/discourse/models/subscription";
 import Transaction from "discourse/plugins/discourse-subscriptions/discourse/models/transaction";
 import I18n from "I18n";
+import { not } from "@ember/object/computed";
 
 export default Controller.extend({
   selectedPlan: null,
-  isAnonymous: Ember.computed.not("currentUser"),
+  isAnonymous: not("currentUser"),
 
   init() {
     this._super(...arguments);

--- a/assets/javascripts/discourse/models/plan.js.es6
+++ b/assets/javascripts/discourse/models/plan.js.es6
@@ -1,8 +1,9 @@
 import EmberObject from "@ember/object";
 import discourseComputed from "discourse-common/utils/decorators";
+import { computed } from "@ember/object";
 
 const Plan = EmberObject.extend({
-  amountDollars: Ember.computed("unit_amount", {
+  amountDollars: computed("unit_amount", {
     get() {
       return parseFloat(this.get("unit_amount") / 100).toFixed(2);
     },


### PR DESCRIPTION
Moving `Ember.computed` constants to imports to ensure compatibility with future versions of Discourse.