### PR TITLE
FIX: Properly show one time payments in user billing

### DIFF
--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -49,6 +49,7 @@ module DiscourseSubscriptions
       def parse_invoice_lines(invoice_lines)
         invoice_product_id = invoice_lines[:price][:product] if invoice_lines[:price] && invoice_lines[:price][:product]
         invoice_product_id = invoice_lines[:plan][:product] if invoice_lines[:plan] && invoice_lines[:plan][:product]
+        invoice_product_id
       end
     end
   end

--- a/plugin.rb
+++ b/plugin.rb
@@ -8,7 +8,7 @@
 
 enabled_site_setting :discourse_subscriptions_enabled
 
-gem 'stripe', '5.22.0'
+gem 'stripe', '5.29.0'
 
 register_asset "stylesheets/common/main.scss"
 register_asset "stylesheets/common/layout.scss"
@@ -44,7 +44,7 @@ load File.expand_path('app/controllers/concerns/stripe.rb', __dir__)
 load File.expand_path('app/controllers/concerns/group.rb', __dir__)
 
 after_initialize do
-  ::Stripe.api_version = "2019-12-03"
+  ::Stripe.api_version = "2020-08-27"
 
   ::Stripe.set_app_info(
     'Discourse Subscriptions',


### PR DESCRIPTION
Encountered a bug where some one time payments were not showing due to an error in the logic.