### PR TITLE
FIX: Properly show one time payments in user billing

### DIFF
--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -49,6 +49,7 @@ module DiscourseSubscriptions
       def parse_invoice_lines(invoice_lines)
         invoice_product_id = invoice_lines[:price][:product] if invoice_lines[:price] && invoice_lines[:price][:product]
         invoice_product_id = invoice_lines[:plan][:product] if invoice_lines[:plan] && invoice_lines[:plan][:product]
+        invoice_product_id
       end
     end
   end


### PR DESCRIPTION
Encountered a bug where some one time payments were not showing under User > Billing > Payments. This was due to a simple error in the logic (and return syntax :man_facepalming: )