### PR TITLE
FEATURE: Support for coupons in checkout

### DIFF
--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -77,7 +77,7 @@ module DiscourseSubscriptions
           invoice_item = ::Stripe::InvoiceItem.create(
             customer: customer[:id],
             price: params[:plan],
-            discounts: { coupon: coupon_id }
+            discounts: [{ coupon: coupon_id }]
           )
           invoice = ::Stripe::Invoice.create(
             customer: customer[:id]

--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -49,7 +49,7 @@ module DiscourseSubscriptions
     end
 
     def create
-      params.require([:source, :plan, :promo])
+      params.require([:source, :plan])
       begin
         customer = create_customer(params[:source])
         plan = ::Stripe::Price.retrieve(params[:plan])

--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -49,28 +49,35 @@ module DiscourseSubscriptions
     end
 
     def create
-      params.require([:source, :plan])
+      params.require([:source, :plan, :promo])
       begin
         customer = create_customer(params[:source])
         plan = ::Stripe::Price.retrieve(params[:plan])
+        promo_code = ::Stripe::PromotionCode.list({ code: params[:promo] }) if params[:promo].present?
+        promo_code = promo_code[:data][0] if promo_code && promo_code[:data] # we assume promo codes have a unique name
 
         recurring_plan = plan[:type] == 'recurring'
 
         if recurring_plan
           trial_days = plan[:metadata][:trial_period_days] if plan[:metadata] && plan[:metadata][:trial_period_days]
 
+          promo_code_id = promo_code[:id] if promo_code
+
           transaction = ::Stripe::Subscription.create(
             customer: customer[:id],
             items: [{ price: params[:plan] }],
             metadata: metadata_user,
-            trial_period_days: trial_days
+            trial_period_days: trial_days,
+            promotion_code: promo_code_id
           )
 
           payment_intent = retrieve_payment_intent(transaction[:latest_invoice]) if transaction[:status] == 'incomplete'
         else
+          coupon_id = promo_code[:coupon][:id] if promo_code && promo_code[:coupon] && promo_code[:coupon][:id]
           invoice_item = ::Stripe::InvoiceItem.create(
             customer: customer[:id],
-            price: params[:plan]
+            price: params[:plan],
+            discounts: { coupon: coupon_id }
           )
           invoice = ::Stripe::Invoice.create(
             customer: customer[:id]

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -6,6 +6,7 @@ import { not } from "@ember/object/computed";
 
 export default Controller.extend({
   selectedPlan: null,
+  promoCode: null,
   isAnonymous: not("currentUser"),
 
   init() {
@@ -32,6 +33,7 @@ export default Controller.extend({
         const subscription = Subscription.create({
           source: result.token.id,
           plan: plan.get("id"),
+          promo: this.promoCode,
         });
 
         return subscription.save();

--- a/assets/javascripts/discourse/models/subscription.js.es6
+++ b/assets/javascripts/discourse/models/subscription.js.es6
@@ -12,6 +12,7 @@ const Subscription = EmberObject.extend({
     const data = {
       source: this.source,
       plan: this.plan,
+      promo: this.promo,
     };
 
     return ajax("/s/create", { method: "post", data });

--- a/assets/javascripts/discourse/models/user-subscription.js.es6
+++ b/assets/javascripts/discourse/models/user-subscription.js.es6
@@ -19,6 +19,22 @@ const UserSubscription = EmberObject.extend({
     }
   },
 
+  @discourseComputed("discount")
+  discounted(discount) {
+    if (discount) {
+      const amount_off = discount.coupon.amount_off;
+      const percent_off = discount.coupon.percent_off;
+
+      if (amount_off) {
+        return `${parseFloat(amount_off * 0.01).toFixed(2)}`;
+      } else if (percent_off) {
+        return `${percent_off}%`;
+      }
+    } else {
+      return I18n.t("no_value");
+    }
+  },
+
   destroy() {
     return ajax(`/s/user/subscriptions/${this.id}`, {
       method: "delete",

--- a/assets/javascripts/discourse/templates/s/show.hbs
+++ b/assets/javascripts/discourse/templates/s/show.hbs
@@ -33,6 +33,9 @@
       {{else if isAnonymous}}
         {{login-required}}
       {{else}}
+        <div class='promo-code'>
+          {{input type="text" name="promo_code" placeholderKey="discourse_subscriptions.subscribe.promo_code" value=promoCode}}
+        </div>
 
         {{d-button
           disabled=loading

--- a/assets/javascripts/discourse/templates/user/billing/subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/user/billing/subscriptions.hbs
@@ -4,7 +4,7 @@
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.id'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.plans.product'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.plans.rate'}}</th>
-      <th>Discounted</th>
+      <th>{{i18n 'discourse_subscriptions.user.subscriptions.discounted'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.status'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.renews'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.created_at'}}</th>

--- a/assets/javascripts/discourse/templates/user/billing/subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/user/billing/subscriptions.hbs
@@ -4,6 +4,7 @@
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.id'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.plans.product'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.plans.rate'}}</th>
+      <th>Discounted</th>
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.status'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.renews'}}</th>
       <th>{{i18n 'discourse_subscriptions.user.subscriptions.created_at'}}</th>
@@ -14,6 +15,7 @@
         <td>{{subscription.id}}</td>
         <td>{{subscription.product.name}}</td>
         <td>{{subscription.plan.subscriptionRate}}</td>
+        <td>{{subscription.discounted}}</td>
         <td>{{subscription.status}}</td>
         <td>{{subscription.endDate}}</td>
         <td>{{format-unix-date subscription.created}}</td>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -53,6 +53,7 @@ en:
         subscriptions:
           id: Subscription ID
           status: Status
+          discounted: Discounted
           renews: Renews
           created_at: Created
           cancel: cancel

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -68,6 +68,7 @@ en:
           title: Payment
         customer:
           title: Customer Details
+        promo_code: Coupon
         buttons:
           subscribe: Subscribe
         purchased: Purchased

--- a/spec/requests/subscribe_controller_spec.rb
+++ b/spec/requests/subscribe_controller_spec.rb
@@ -213,7 +213,7 @@ module DiscourseSubscriptions
                 }
               )
 
-              ::Stripe::InvoiceItem.expects(:create).with(customer: 'cus_1234', price: 'plan_1234', discounts: [{ coupon: 'c123'}])
+              ::Stripe::InvoiceItem.expects(:create).with(customer: 'cus_1234', price: 'plan_1234', discounts: [{ coupon: 'c123' }])
 
               ::Stripe::Invoice.expects(:create).returns(status: 'open', id: 'in_123')
 

--- a/spec/requests/subscribe_controller_spec.rb
+++ b/spec/requests/subscribe_controller_spec.rb
@@ -128,7 +128,8 @@ module DiscourseSubscriptions
               customer: 'cus_1234',
               items: [ price: 'plan_1234' ],
               metadata: { user_id: user.id, username: user.username_lower },
-              trial_period_days: 0
+              trial_period_days: 0,
+              promotion_code: nil
             ).returns(status: 'active', customer: 'cus_1234')
 
             expect {
@@ -169,6 +170,63 @@ module DiscourseSubscriptions
             expect {
               post "/s/create.json", params: { plan: 'plan_1234', source: 'tok_1234' }
             }.to change { DiscourseSubscriptions::Customer.count }
+          end
+
+          context "with promo code" do
+            before do
+              ::Stripe::PromotionCode.expects(:list).with({ code: '123' }).returns(
+                data: [{
+                  id: 'promo123',
+                  coupon: { id: 'c123' }
+                }]
+              )
+            end
+
+            it "applies promo code to recurring subscription" do
+              ::Stripe::Price.expects(:retrieve).returns(
+                type: 'recurring',
+                product: 'product_12345',
+                metadata: {
+                  group_name: 'awesome',
+                  trial_period_days: 0
+                }
+              )
+
+              ::Stripe::Subscription.expects(:create).with(
+                customer: 'cus_1234',
+                items: [ price: 'plan_1234' ],
+                metadata: { user_id: user.id, username: user.username_lower },
+                trial_period_days: 0,
+                promotion_code: 'promo123'
+              ).returns(status: 'active', customer: 'cus_1234')
+
+              post "/s/create.json", params: { plan: 'plan_1234', source: 'tok_1234', promo: '123' }
+
+            end
+
+            it "applies promo code to one time purchase" do
+              ::Stripe::Price.expects(:retrieve).returns(
+                type: 'one_time',
+                product: 'product_12345',
+                metadata: {
+                  group_name: 'awesome'
+                }
+              )
+
+              ::Stripe::InvoiceItem.expects(:create).with(customer: 'cus_1234', price: 'plan_1234', discounts: [{ coupon: 'c123'}])
+
+              ::Stripe::Invoice.expects(:create).returns(status: 'open', id: 'in_123')
+
+              ::Stripe::Invoice.expects(:finalize_invoice).returns(id: 'in_123', status: 'open', payment_intent: 'pi_123')
+
+              ::Stripe::Invoice.expects(:retrieve).returns(id: 'in_123', status: 'open', payment_intent: 'pi_123')
+
+              ::Stripe::PaymentIntent.expects(:retrieve).returns(status: 'successful')
+
+              ::Stripe::Invoice.expects(:pay).returns(status: 'paid', customer: 'cus_1234')
+
+              post '/s/create.json', params: { plan: 'plan_1234', source: 'tok_1234', promo: '123' }
+            end
           end
         end
 


### PR DESCRIPTION
This adds support for Stripe Promo Codes in the user checkout process. 

![image](https://user-images.githubusercontent.com/11862022/103822646-22f6fc80-5036-11eb-94a4-8ae101e03402.png)

Also adds a discounted field to User > Billing > Subscriptions to show the amount or percent discounted.

![image](https://user-images.githubusercontent.com/11862022/103822721-48840600-5036-11eb-8461-ce327e8be84f.png)

This does not currently add in support for creating promo codes in the Subscriptions interface (that will come at a later point in time). Instead a coupon can be created with a promo code right from the Stripe dashboard.