### PR TITLE
FEATURE: Give option to repurchase products multiple times

### DIFF
--- a/app/controllers/discourse_subscriptions/admin/products_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/products_controller.rb
@@ -93,7 +93,10 @@ module DiscourseSubscriptions
           name: params[:name],
           active: params[:active],
           statement_descriptor: params[:statement_descriptor],
-          metadata: { description: params.dig(:metadata, :description) }
+          metadata: {
+            description: params.dig(:metadata, :description),
+            repurchaseable: params.dig(:metadata, :repurchaseable)
+          }
         }
       end
     end

--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -136,7 +136,8 @@ module DiscourseSubscriptions
         id: product[:id],
         name: product[:name],
         description: PrettyText.cook(product[:metadata][:description]),
-        subscribed: current_user_products.include?(product[:id])
+        subscribed: current_user_products.include?(product[:id]),
+        repurchaseable: product[:metadata][:repurchaseable]
       }
     end
 

--- a/assets/javascripts/discourse/components/product-item.js.es6
+++ b/assets/javascripts/discourse/components/product-item.js.es6
@@ -1,0 +1,5 @@
+import Component from "@ember/component";
+
+export default Component.extend({
+  classNames: ["product"],
+});

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -3,6 +3,7 @@ import Subscription from "discourse/plugins/discourse-subscriptions/discourse/mo
 import Transaction from "discourse/plugins/discourse-subscriptions/discourse/models/transaction";
 import I18n from "I18n";
 import { not } from "@ember/object/computed";
+import discourseComputed from "discourse-common/utils/decorators";
 
 export default Controller.extend({
   selectedPlan: null,
@@ -22,6 +23,17 @@ export default Controller.extend({
 
   alert(path) {
     bootbox.alert(I18n.t(`discourse_subscriptions.${path}`));
+  },
+
+  @discourseComputed("model.product.repurchaseable", "model.product.subscribed")
+  canPurchase(repurchaseable, subscribed) {
+    if (repurchaseable && subscribed) {
+      return true;
+    } else if (!repurchaseable && subscribed) {
+      return false;
+    }
+
+    return true;
   },
 
   createSubscription(plan) {

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -27,9 +27,7 @@ export default Controller.extend({
 
   @discourseComputed("model.product.repurchaseable", "model.product.subscribed")
   canPurchase(repurchaseable, subscribed) {
-    if (repurchaseable && subscribed) {
-      return true;
-    } else if (!repurchaseable && subscribed) {
+    if (!repurchaseable && subscribed) {
       return false;
     }
 

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show.hbs
@@ -24,6 +24,13 @@
     </div>
   </p>
   <p>
+    <label for="repurchaseable">{{i18n 'discourse_subscriptions.admin.products.product.repurchaseable'}}</label>
+    {{input type="checkbox" name="repurchaseable" checked=model.product.metadata.repurchaseable}}
+    <div class="control-instructions">
+      {{i18n 'discourse_subscriptions.admin.products.product.repurchase_help'}}
+    </div>
+  </p>
+  <p>
     <label for="active">{{i18n 'discourse_subscriptions.admin.products.product.active'}}</label>
     {{input type="checkbox" name="active" checked=model.product.active}}
     <div class="control-instructions">

--- a/assets/javascripts/discourse/templates/components/product-item.hbs
+++ b/assets/javascripts/discourse/templates/components/product-item.hbs
@@ -1,0 +1,32 @@
+<h2>{{product.name}}</h2>
+
+<p class="product-description">
+  {{html-safe product.description}}
+</p>
+
+{{#if isLoggedIn}}
+  <div class="product-purchase">
+    {{#if product.repurchaseable}}
+      {{#if product.subscribed}}
+        <span class="purchased">&#x2713; {{i18n 'discourse_subscriptions.subscribe.purchased'}}</span>
+        {{#link-to "user.billing.subscriptions" currentUser.username class="billing-link"}}
+          {{i18n 'discourse_subscriptions.subscribe.go_to_billing'}}
+        {{/link-to}}
+      {{/if}}
+      {{#link-to "s.show" product.id class="btn btn-primary"}}
+        {{i18n 'discourse_subscriptions.subscribe.title'}}
+      {{/link-to}}
+    {{else}}
+      {{#if product.subscribed}}
+        <span class="purchased">&#x2713; {{i18n 'discourse_subscriptions.subscribe.purchased'}}</span>
+        {{#link-to "user.billing.subscriptions" currentUser.username class="billing-link"}}
+          {{i18n 'discourse_subscriptions.subscribe.go_to_billing'}}
+        {{/link-to}}
+      {{else}}
+        {{#link-to "s.show" product.id disabled=product.subscribed class="btn btn-primary"}}
+          {{i18n 'discourse_subscriptions.subscribe.title'}}
+        {{/link-to}}
+      {{/if}}
+    {{/if}}
+  </div>
+{{/if}}

--- a/assets/javascripts/discourse/templates/components/product-list.hbs
+++ b/assets/javascripts/discourse/templates/components/product-list.hbs
@@ -2,28 +2,6 @@
   <p>{{i18n 'discourse_subscriptions.subscribe.no_products'}}</p>
 {{else}}
   {{#each products as |product|}}
-    <div class="product">
-      <h2>{{product.name}}</h2>
-
-      <p class="product-description">
-        {{html-safe product.description}}
-      </p>
-
-      {{#if isLoggedIn}}
-        <div class="product-purchase">
-          {{#if product.subscribed}}
-            <span class="purchased">&#x2713; {{i18n 'discourse_subscriptions.subscribe.purchased'}}</span>
-            {{#link-to "user.billing.subscriptions" currentUser.username class="billing-link"}}
-              {{i18n 'discourse_subscriptions.subscribe.go_to_billing'}}
-            {{/link-to}}
-          {{else}}
-            {{#link-to "s.show" product.id disabled=product.subscribed class="btn btn-primary"}}
-              {{i18n 'discourse_subscriptions.subscribe.title'}}
-            {{/link-to}}
-          {{/if}}
-        </div>
-      {{/if}}
-    </div>
+    {{product-item product=product isLoggedIn=isLoggedIn}}
   {{/each}}
-
 {{/if}}

--- a/assets/javascripts/discourse/templates/s/show.hbs
+++ b/assets/javascripts/discourse/templates/s/show.hbs
@@ -12,7 +12,7 @@
     </p>
   </div>
   <div class="section-column">
-    {{#unless model.product.subscribed}}
+    {{#if canPurchase}}
       <h2>
         {{i18n 'discourse_subscriptions.subscribe.card.title'}}
       </h2>
@@ -45,6 +45,6 @@
         }}
       {{/if}}
 
-    {{/unless}}
+    {{/if}}
   </div>
 </div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -111,6 +111,8 @@ en:
             plan_help: Create a pricing plan to subscribe customers to this product.
             description: Description
             description_help: This describes your subscription product.
+            repurchaseable: Repurchaseable?
+            repurchase_help: Allow product and associated plans to be purchased multiple times
             active: Active
             active_help: Toggle this off until your product is ready for consumers.
             created_at: Created

--- a/spec/requests/admin/products_controller_spec.rb
+++ b/spec/requests/admin/products_controller_spec.rb
@@ -81,9 +81,15 @@ module DiscourseSubscriptions
             post "/s/admin/products.json", params: { statement_descriptor: '' }
           end
 
-          it 'has a description' do
-            ::Stripe::Product.expects(:create).with(has_entry(metadata: { description: 'Oi, I think he just said bless be all the bignoses!' }))
-            post "/s/admin/products.json", params: { metadata: { description: 'Oi, I think he just said bless be all the bignoses!' } }
+          it 'has metadata' do
+            ::Stripe::Product.expects(:create).with(has_entry(metadata: { description: 'Oi, I think he just said bless be all the bignoses!', repurchaseable: 'false' }))
+
+            post "/s/admin/products.json", params: {
+              metadata: {
+                description: 'Oi, I think he just said bless be all the bignoses!',
+                repurchaseable: 'false'
+              }
+            }
           end
         end
 

--- a/spec/requests/subscribe_controller_spec.rb
+++ b/spec/requests/subscribe_controller_spec.rb
@@ -12,7 +12,8 @@ module DiscourseSubscriptions
           id: "prodct_23456",
           name: "Very Special Product",
           metadata: {
-            description: "Many people listened to my phone call with the Ukrainian President while it was being made"
+            description: "Many people listened to my phone call with the Ukrainian President while it was being made",
+            repurchaseable: false
           },
           otherstuff: true,
         }
@@ -48,7 +49,8 @@ module DiscourseSubscriptions
             "id" => "prodct_23456",
             "name" => "Very Special Product",
             "description" => PrettyText.cook("Many people listened to my phone call with the Ukrainian President while it was being made"),
-            "subscribed" => false
+            "subscribed" => false,
+            "repurchaseable" => false,
           }])
         end
 
@@ -82,7 +84,8 @@ module DiscourseSubscriptions
              "id" => "prodct_23456",
              "name" => "Very Special Product",
              "description" => PrettyText.cook("Many people listened to my phone call with the Ukrainian President while it was being made"),
-             "subscribed" => false
+             "subscribed" => false,
+             "repurchaseable" => false
            },
            "plans" => [
              { "currency" => "aud", "id" => "plan_id123", "recurring" => { "interval" => "year" }, "unit_amount" => 1220 },


### PR DESCRIPTION
Feature requested here: https://meta.discourse.org/t/subscriptions-allow-users-to-purchase-one-time-products-multiple-times/173732/

There may be cases where a site admin wants to allow the repurchasing of a product. This implements the functionality by adding a repurchaseable toggle in the admin screen when creating a product. This saves an attribute to the Stripe product metadata.

When a user has already purchased an item with this toggle enabled, they will be able to purchase it again when browsing to `/s`.