### PR TITLE
FEATURE: Admin > Subscriptions Pagination

### DIFF
--- a/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
@@ -23,13 +23,13 @@ module DiscourseSubscriptions
             while subscriptions[:length] < PAGE_LIMIT
               current_set = get_subscriptions(subscriptions[:last_record])
 
-              until valid_subscriptions = find_valid_subscriptions(current_set['data'], subscription_ids) do
+              until valid_subscriptions = find_valid_subscriptions(current_set[:data], subscription_ids) do
                 current_set = get_subscriptions(current_set[:data].last)
                 break if current_set[:has_more] == false
               end
 
               subscriptions[:data] = subscriptions[:data].concat(valid_subscriptions.to_a)
-              subscriptions[:last_record] = current_set['data'].last[:id]
+              subscriptions[:last_record] = current_set[:data].last[:id] if current_set[:data].present?
               subscriptions[:length] = subscriptions[:data].length
               subscriptions[:has_more] = current_set[:has_more]
               break if subscriptions[:has_more] == false

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
@@ -1,11 +1,9 @@
-import { alias } from "@ember/object/computed";
 import AdminSubscription from "discourse/plugins/discourse-subscriptions/discourse/models/admin-subscription";
 import Controller from "@ember/controller";
 import showModal from "discourse/lib/show-modal";
 
 export default Controller.extend({
   loading: false,
-  canLoadMore: alias("model.has_more"),
 
   actions: {
     showCancelModal(subscription) {
@@ -15,10 +13,10 @@ export default Controller.extend({
     },
 
     loadMore() {
-      if (!this.loading && this.canLoadMore) {
+      if (!this.loading && this.model.has_more) {
         this.set("loading", true);
 
-        AdminSubscription.loadMore(this.model.last_record).then((result) => {
+        return AdminSubscription.loadMore(this.model.last_record).then((result) => {
           const updated = this.model.data.concat(result.data);
           this.set("model", result);
           this.set("model.data", updated);

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
@@ -18,7 +18,7 @@ export default Controller.extend({
       if (!this.loading && this.canLoadMore) {
         this.set("loading", true);
 
-        AdminSubscription.loadMore(this.model.next_page).then((result) => {
+        AdminSubscription.loadMore(this.model.last_record).then((result) => {
           const updated = this.model.data.concat(result.data);
           this.set("model", result);
           this.set("model.data", updated);

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
@@ -1,12 +1,30 @@
+import { alias } from "@ember/object/computed";
+import AdminSubscription from "discourse/plugins/discourse-subscriptions/discourse/models/admin-subscription";
 import Controller from "@ember/controller";
 import showModal from "discourse/lib/show-modal";
 
 export default Controller.extend({
+  loading: false,
+  canLoadMore: alias("model.has_more"),
+
   actions: {
     showCancelModal(subscription) {
       showModal("admin-cancel-subscription", {
         model: subscription,
       });
+    },
+
+    loadMore() {
+      if (!this.loading && this.canLoadMore) {
+        this.set("loading", true);
+
+        AdminSubscription.loadMore(this.model.next_page).then((result) => {
+          const updated = this.model.data.concat(result.data);
+          this.set("model", result);
+          this.set("model.data", updated);
+          this.set("loading", false);
+        });
+      }
     },
   },
 });

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js.es6
@@ -16,12 +16,14 @@ export default Controller.extend({
       if (!this.loading && this.model.has_more) {
         this.set("loading", true);
 
-        return AdminSubscription.loadMore(this.model.last_record).then((result) => {
-          const updated = this.model.data.concat(result.data);
-          this.set("model", result);
-          this.set("model.data", updated);
-          this.set("loading", false);
-        });
+        return AdminSubscription.loadMore(this.model.last_record).then(
+          (result) => {
+            const updated = this.model.data.concat(result.data);
+            this.set("model", result);
+            this.set("model.data", updated);
+            this.set("loading", false);
+          }
+        );
       }
     },
   },

--- a/assets/javascripts/discourse/models/admin-subscription.js.es6
+++ b/assets/javascripts/discourse/models/admin-subscription.js.es6
@@ -44,8 +44,8 @@ AdminSubscription.reopenClass({
       return result;
     });
   },
-  loadMore(page) {
-    return ajax(`/s/admin/subscriptions?page=${page}`, {
+  loadMore(lastRecord) {
+    return ajax(`/s/admin/subscriptions?last_record=${lastRecord}`, {
       method: "get",
     }).then((result) => {
       result.data = result.data.map((subscription) =>

--- a/assets/javascripts/discourse/models/admin-subscription.js.es6
+++ b/assets/javascripts/discourse/models/admin-subscription.js.es6
@@ -38,9 +38,20 @@ AdminSubscription.reopenClass({
       if (result === null) {
         return { unconfigured: true };
       }
-      return result.map((subscription) =>
+      result.data = result.data.map((subscription) =>
         AdminSubscription.create(subscription)
       );
+      return result;
+    });
+  },
+  loadMore(page) {
+    return ajax(`/s/admin/subscriptions?page=${page}`, {
+      method: "get",
+    }).then((result) => {
+      result.data = result.data.map((subscription) =>
+        AdminSubscription.create(subscription)
+      );
+      return result;
     });
   },
 });

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-subscriptions.hbs
@@ -2,42 +2,45 @@
   <p>{{i18n 'discourse_subscriptions.admin.unconfigured'}}</p>
   <p><a href="https://meta.discourse.org/t/discourse-subscriptions/140818/">Discourse Subscriptions on Meta</a></p>
 {{else}}
-  <table class="table discourse-patrons-table">
-    <thead>
-      <tr>
-        <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.user'}}</th>
-        <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.subscription_id'}}</th>
-        <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.customer'}}</th>
-        <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.product'}}</th>
-        <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.plan'}}</th>
-        <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.status'}}</th>
-        <th class="td-right">{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.created_at'}}</th>
-        <th></th>
-      </tr>
-    </thead>
-    {{#each model as |subscription|}}
-      <tr>
-        <td>
-          {{#if subscription.metadataUserExists}}
-            <a href="{{unbound subscription.subscriptionUserPath}}">
-              {{subscription.metadata.username}}
-            </a>
-          {{/if}}
-        </td>
-        <td>{{subscription.id}}</td>
-        <td>{{subscription.customer}}</td>
-        <td>{{subscription.plan.product.name}}</td>
-        <td>{{subscription.plan.nickname}}</td>
-        <td>{{subscription.status}}</td>
-        <td class="td-right">{{format-unix-date subscription.created}}</td>
-        <td class="td-right">
-          {{#if subscription.loading}}
-            {{loading-spinner size="small"}}
-          {{else}}
-            {{d-button disabled=subscription.canceled label="cancel" action=(action "showCancelModal" subscription) icon="times"}}
-          {{/if}}
-        </td>
-      </tr>
-    {{/each}}
-  </table>
+  {{#load-more selector=".discourse-patrons-table tr" action=(action "loadMore")}}
+    <table class="table discourse-patrons-table">
+      <thead>
+        <tr>
+          <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.user'}}</th>
+          <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.subscription_id'}}</th>
+          <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.customer'}}</th>
+          <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.product'}}</th>
+          <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.plan'}}</th>
+          <th>{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.status'}}</th>
+          <th class="td-right">{{i18n 'discourse_subscriptions.admin.subscriptions.subscription.created_at'}}</th>
+          <th></th>
+        </tr>
+      </thead>
+      {{#each model.data as |subscription|}}
+        <tr>
+          <td>
+            {{#if subscription.metadataUserExists}}
+              <a href="{{unbound subscription.subscriptionUserPath}}">
+                {{subscription.metadata.username}}
+              </a>
+            {{/if}}
+          </td>
+          <td>{{subscription.id}}</td>
+          <td>{{subscription.customer}}</td>
+          <td>{{subscription.plan.product.name}}</td>
+          <td>{{subscription.plan.nickname}}</td>
+          <td>{{subscription.status}}</td>
+          <td class="td-right">{{format-unix-date subscription.created}}</td>
+          <td class="td-right">
+            {{#if subscription.loading}}
+              {{loading-spinner size="small"}}
+            {{else}}
+              {{d-button disabled=subscription.canceled label="cancel" action=(action "showCancelModal" subscription) icon="times"}}
+            {{/if}}
+          </td>
+        </tr>
+      {{/each}}
+    </table>
+  {{/load-more}}
+  {{conditional-loading-spinner condition=loading}}
 {{/if}}


### PR DESCRIPTION
Meta topic: https://meta.discourse.org/t/subscriptions-add-pagination-to-admin-subscriptions-view/172500

This adds support for pagination using our `{{load-more}}` component in core. Implementation on the backend was a bit tricky because we don't return all results from Stripe, only those that match local subscriptions stored in the `DiscourseSubscriptions::Subscription` model. 