### PR TITLE
DEV: Remove unused CSS selector

### DIFF
--- a/assets/stylesheets/common/main.scss
+++ b/assets/stylesheets/common/main.scss
@@ -54,11 +54,6 @@ table.discourse-subscriptions-user-table {
   }
 }
 
-.desc {
-  color: dark-light-choose($primary-medium, $secondary-medium);
-  font-size: 0.8em;
-}
-
 .discourse-subscriptions-admin-textarea {
   width: 80%;
 }


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/subscriptions-desc-style-overrides-user-cards/177478

This selector wasn't even used anywhere in the plugin but overrides styles in core.

