### PR TITLE
FIX: Restrict mods from seeing Subscriptions admin features

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,12 +8,12 @@ DiscourseSubscriptions::Engine.routes.draw do
     post '/create-campaign' => 'admin#create_campaign'
   end
 
-  namespace :admin do
-    resources :plans, constraints: AdminConstraint.new
-    resources :subscriptions, only: [:index, :destroy], constraints: AdminConstraint.new
-    resources :products, constraints: AdminConstraint.new
-    resources :coupons, only: [:index, :create], constraints: AdminConstraint.new
-    resource :coupons, only: [:destroy, :update], constraints: AdminConstraint.new
+  namespace :admin, constraints: AdminConstraint.new do
+    resources :plans
+    resources :subscriptions, only: [:index, :destroy]
+    resources :products
+    resources :coupons, only: [:index, :create]
+    resource :coupons, only: [:destroy, :update]
   end
 
   namespace :user do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,11 @@ DiscourseSubscriptions::Engine.routes.draw do
   end
 
   namespace :admin do
-    resources :plans
-    resources :subscriptions, only: [:index, :destroy]
-    resources :products
-    resources :coupons, only: [:index, :create]
-    resource :coupons, only: [:destroy, :update]
+    resources :plans, constraints: AdminConstraint.new
+    resources :subscriptions, only: [:index, :destroy], constraints: AdminConstraint.new
+    resources :products, constraints: AdminConstraint.new
+    resources :coupons, only: [:index, :create], constraints: AdminConstraint.new
+    resource :coupons, only: [:destroy, :update], constraints: AdminConstraint.new
   end
 
   namespace :user do

--- a/spec/requests/admin/coupons_controller_spec.rb
+++ b/spec/requests/admin/coupons_controller_spec.rb
@@ -12,7 +12,7 @@ module DiscourseSubscriptions
       it "does nothing" do
         ::Stripe::PromotionCode.expects(:list).never
         get "/s/admin/coupons.json"
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(404)
       end
     end
 

--- a/spec/requests/admin/plans_controller_spec.rb
+++ b/spec/requests/admin/plans_controller_spec.rb
@@ -18,7 +18,7 @@ module DiscourseSubscriptions
 
           it "not ok" do
             get "/s/admin/plans.json"
-            expect(response.status).to eq 403
+            expect(response.status).to eq 404
           end
         end
 
@@ -30,7 +30,7 @@ module DiscourseSubscriptions
 
           it "is not ok" do
             post "/s/admin/plans.json", params: { name: 'Rick Astley', amount: 1, interval: 'week' }
-            expect(response.status).to eq 403
+            expect(response.status).to eq 404
           end
         end
 
@@ -42,7 +42,7 @@ module DiscourseSubscriptions
 
           it "is not ok" do
             get "/s/admin/plans/plan_12345.json"
-            expect(response.status).to eq 403
+            expect(response.status).to eq 404
           end
         end
 

--- a/spec/requests/admin/products_controller_spec.rb
+++ b/spec/requests/admin/products_controller_spec.rb
@@ -13,31 +13,31 @@ module DiscourseSubscriptions
         it "does not list the products" do
           ::Stripe::Product.expects(:list).never
           get "/s/admin/products.json"
-          expect(response.status).to eq(403)
+          expect(response.status).to eq(404)
         end
 
         it "does not create the product" do
           ::Stripe::Product.expects(:create).never
           post "/s/admin/products.json"
-          expect(response.status).to eq(403)
+          expect(response.status).to eq(404)
         end
 
         it "does not show the product" do
           ::Stripe::Product.expects(:retrieve).never
           get "/s/admin/products/prod_qwerty123.json"
-          expect(response.status).to eq(403)
+          expect(response.status).to eq(404)
         end
 
         it "does not update the product" do
           ::Stripe::Product.expects(:update).never
           put "/s/admin/products/prod_qwerty123.json"
-          expect(response.status).to eq(403)
+          expect(response.status).to eq(404)
         end
 
         it "does not delete the product" do
           ::Stripe::Product.expects(:delete).never
           delete "/s/admin/products/u2.json"
-          expect(response.status).to eq(403)
+          expect(response.status).to eq(404)
         end
       end
 

--- a/spec/requests/admin/subscriptions_controller_spec.rb
+++ b/spec/requests/admin/subscriptions_controller_spec.rb
@@ -20,7 +20,7 @@ module DiscourseSubscriptions
       it "does nothing" do
         ::Stripe::Subscription.expects(:list).never
         get "/s/admin/subscriptions.json"
-        expect(response.status).to eq(403)
+        expect(response.status).to eq(404)
       end
 
       it "does not destroy a subscription" do


### PR DESCRIPTION
As reported [on Meta](https://meta.discourse.org/t/discourse-subscriptions/140818/352?u=justin), moderators could access all of the subscriptions data (plugins/prices/subscribers) and manage them. This should not be the case, so this PR adds a route constraint to 404 moderators from these routes.