### PR TITLE
FEATURE: Validate coupon codes on form submit

### DIFF
--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -65,8 +65,13 @@ module DiscourseSubscriptions
       begin
         customer = create_customer(params[:source])
         plan = ::Stripe::Price.retrieve(params[:plan])
-        promo_code = ::Stripe::PromotionCode.list({ code: params[:promo] }) if params[:promo].present?
-        promo_code = promo_code[:data][0] if promo_code && promo_code[:data] # we assume promo codes have a unique name
+
+        if params[:promo].present?
+          promo_code = ::Stripe::PromotionCode.list({ code: params[:promo] })
+          promo_code = promo_code[:data][0] # we assume promo codes have a unique name
+
+          return render_json_error I18n.t("js.discourse_subscriptions.subscribe.invalid_coupon") if promo_code.blank?
+        end
 
         recurring_plan = plan[:type] == 'recurring'
 

--- a/assets/javascripts/discourse/controllers/s-show.js.es6
+++ b/assets/javascripts/discourse/controllers/s-show.js.es6
@@ -121,7 +121,9 @@ export default Controller.extend({
           }
         })
         .catch((result) => {
-          bootbox.alert(result.errorThrown);
+          bootbox.alert(
+            result.jqXHR.responseJSON.errors[0] || result.errorThrown
+          );
           this.set("loading", false);
         });
     },

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -100,6 +100,7 @@ en:
         view_past: View past purchases
         no_products: There are currently no products available.
         unauthenticated: Log in or create an account to subscribe.
+        invalid_coupon: You entered an invalid coupon code. Please try again.
         card:
           title: Payment
         customer:

--- a/spec/requests/subscribe_controller_spec.rb
+++ b/spec/requests/subscribe_controller_spec.rb
@@ -251,7 +251,6 @@ module DiscourseSubscriptions
                 )
               end
 
-
               it "applies promo code to recurring subscription" do
                 ::Stripe::Price.expects(:retrieve).returns(
                   type: 'recurring',


### PR DESCRIPTION
As reported on [Meta](https://meta.discourse.org/t/validate-coupon-codes/193181/), we weren't validating coupon codes on form submission, so an incorrect code could be used and no feedback was given to the end user. This PR fixes that up.