### PR TITLE
fix strong

### DIFF
--- a/assets/javascripts/discourse/templates/components/campaign-banner.hbs
+++ b/assets/javascripts/discourse/templates/components/campaign-banner.hbs
@@ -29,7 +29,7 @@
         <p class="campaign-banner-progress-success">{{i18n 'discourse_subscriptions.campaign.goal'}}!</p>
         {{#if subscriberGoal}}
           <p class="campaign-banner-progress-description">
-            {{i18n 'discourse_subscriptions.campaign.goal_comparison' current=subscribers goal=goalTarget}}
+            {{html-safe (i18n 'discourse_subscriptions.campaign.goal_comparison' current=subscribers goal=goalTarget)}}
             {{i18n 'discourse_subscriptions.campaign.subscribers'}}
           </p>
         {{else}}


### PR DESCRIPTION
I think the Subscriber option should be `html-safe` like the Amount option otherwise you get this rendered in the browser:
![Screenshot from 2021-06-19 15-35-38](https://user-images.githubusercontent.com/6521546/122632129-0fd37700-d114-11eb-9f48-d9c3e1d7a46a.png)
