### PR TITLE
FIX: New user sessions redirected weirdly on login_required sites

### DIFF
--- a/assets/javascripts/discourse/components/campaign-banner.js.es6
+++ b/assets/javascripts/discourse/components/campaign-banner.js.es6
@@ -52,7 +52,7 @@ export default Component.extend({
       }
     }
 
-    if (this.showContributors) {
+    if (this.currentUser && this.showContributors) {
       return ajax("/s/contributors", { method: "get" }).then((result) => {
         this.setProperties({
           contributors: result,


### PR DESCRIPTION
Very simple change here -- don't run the `/s/contributors` AJAX call unless the user is currently logged in. On `login_required` sites, allowing this call to run has a number of weird side-effects, including setting the `destination_url` cookie to `/s/contributors`. 

Instead, since we don't show the banner to anonymous users, we only need to allow this call when the user is currently logged in.