### PR TITLE
FEATURE: Show/hide campaign banner with goal status

### DIFF
--- a/app/services/discourse_subscriptions/campaign.rb
+++ b/app/services/discourse_subscriptions/campaign.rb
@@ -31,6 +31,8 @@ module DiscourseSubscriptions
       end
 
       SiteSetting.discourse_subscriptions_campaign_amount_raised = amount
+
+      check_goal_status
     end
 
     def create_campaign
@@ -47,6 +49,21 @@ module DiscourseSubscriptions
     end
 
     protected
+
+    def check_goal_status
+      original_status = SiteSetting.discourse_subscriptions_campaign_goal_met.dup
+      goal = SiteSetting.discourse_subscriptions_campaign_goal
+      goal_type = SiteSetting.discourse_subscriptions_campaign_type
+
+      case goal_type
+      when "Amount"
+        current_volume = SiteSetting.discourse_subscriptions_campaign_amount_raised
+      when "Subscribers"
+        current_volume = SiteSetting.discourse_subscriptions_campaign_subscribers
+      end
+
+      SiteSetting.discourse_subscriptions_campaign_goal_met = current_volume > goal
+    end
 
     def create_campaign_group
       campaign_group = SiteSetting.discourse_subscriptions_campaign_group

--- a/app/services/discourse_subscriptions/campaign.rb
+++ b/app/services/discourse_subscriptions/campaign.rb
@@ -63,6 +63,7 @@ module DiscourseSubscriptions
       end
 
       SiteSetting.discourse_subscriptions_campaign_goal_met = current_volume > goal
+      SiteSetting.discourse_subscriptions_campaign_goal_met_date = Time.now.to_f * 1000 # convert to ms so client can parse
     end
 
     def create_campaign_group

--- a/assets/javascripts/discourse/components/campaign-banner.js.es6
+++ b/assets/javascripts/discourse/components/campaign-banner.js.es6
@@ -28,6 +28,7 @@ export default Component.extend({
   ),
   currency: setting("discourse_subscriptions_currency"),
   goalTarget: setting("discourse_subscriptions_campaign_goal"),
+  isGoalMet: setting("discourse_subscriptions_campaign_goal_met"),
   product: setting("discourse_subscriptions_campaign_product"),
   showContributors: setting(
     "discourse_subscriptions_campaign_show_contributors"
@@ -159,14 +160,6 @@ export default Component.extend({
     return (
       this.siteSettings.discourse_subscriptions_campaign_amount_raised / 100
     );
-  },
-
-  @discourseComputed
-  isGoalMet() {
-    const currentVolume = this.subscriberGoal
-      ? this.subscribers
-      : this.amountRaised;
-    return currentVolume >= this.goalTarget;
   },
 
   @action

--- a/assets/javascripts/discourse/components/campaign-banner.js.es6
+++ b/assets/javascripts/discourse/components/campaign-banner.js.es6
@@ -29,8 +29,6 @@ export default Component.extend({
   currency: setting("discourse_subscriptions_currency"),
   amountRaised: setting("discourse_subscriptions_campaign_amount_raised"),
   goalTarget: setting("discourse_subscriptions_campaign_goal"),
-  isGoalMet: setting("discourse_subscriptions_campaign_goal_met"),
-  goalMetDate: setting("discourse_subscriptions_campaign_goal_met_date"),
   product: setting("discourse_subscriptions_campaign_product"),
   showContributors: setting(
     "discourse_subscriptions_campaign_show_contributors"
@@ -123,12 +121,7 @@ export default Component.extend({
       !currentRoute.split(".")[0].includes("admin") &&
       currentRoute.split(".")[0] !== "s";
 
-    // if the goal is met and the date is > 7 days, don't show
-    const now = Date.now();
-    const goalDate = new Date(parseFloat(this.goalMetDate));
-    const goalComparison = now - goalDate > 86400000 * 7;
-
-    if (this.goalMetDate && goalComparison) {
+    if (!this.site.show_campaign_banner) {
       return false;
     }
 
@@ -164,6 +157,14 @@ export default Component.extend({
       (!dismissedBannerKey || now - bannerDismissedTime > threeMonths) &&
       !dismissed
     );
+  },
+
+  @discourseComputed
+  isGoalMet() {
+    const currentVolume = this.subscriberGoal
+      ? this.subscribers
+      : this.amountRaised;
+    return currentVolume >= this.goalTarget;
   },
 
   @action

--- a/assets/javascripts/discourse/components/campaign-banner.js.es6
+++ b/assets/javascripts/discourse/components/campaign-banner.js.es6
@@ -29,6 +29,7 @@ export default Component.extend({
   currency: setting("discourse_subscriptions_currency"),
   goalTarget: setting("discourse_subscriptions_campaign_goal"),
   isGoalMet: setting("discourse_subscriptions_campaign_goal_met"),
+  goalMetDate: setting("discourse_subscriptions_campaign_goal_met_date"),
   product: setting("discourse_subscriptions_campaign_product"),
   showContributors: setting(
     "discourse_subscriptions_campaign_show_contributors"
@@ -120,6 +121,15 @@ export default Component.extend({
       currentRoute !== "discovery.s" &&
       !currentRoute.split(".")[0].includes("admin") &&
       currentRoute.split(".")[0] !== "s";
+
+    // if the goal is met and the date is > 7 days, don't show
+    const now = Date.now();
+    const goalDate = new Date(parseFloat(this.goalMetDate));
+    const goalComparison = now - goalDate > 86400000 * 7;
+
+    if (this.isGoalMet && this.goalMetDate && goalComparison) {
+      return false;
+    }
 
     // make sure not to render above main container when inside a topic
     if (

--- a/assets/javascripts/discourse/components/campaign-banner.js.es6
+++ b/assets/javascripts/discourse/components/campaign-banner.js.es6
@@ -27,6 +27,7 @@ export default Component.extend({
     "Subscribers"
   ),
   currency: setting("discourse_subscriptions_currency"),
+  amountRaised: setting("discourse_subscriptions_campaign_amount_raised"),
   goalTarget: setting("discourse_subscriptions_campaign_goal"),
   isGoalMet: setting("discourse_subscriptions_campaign_goal_met"),
   goalMetDate: setting("discourse_subscriptions_campaign_goal_met_date"),
@@ -127,7 +128,7 @@ export default Component.extend({
     const goalDate = new Date(parseFloat(this.goalMetDate));
     const goalComparison = now - goalDate > 86400000 * 7;
 
-    if (this.isGoalMet && this.goalMetDate && goalComparison) {
+    if (this.goalMetDate && goalComparison) {
       return false;
     }
 
@@ -162,13 +163,6 @@ export default Component.extend({
     return (
       (!dismissedBannerKey || now - bannerDismissedTime > threeMonths) &&
       !dismissed
-    );
-  },
-
-  @discourseComputed
-  amountRaised() {
-    return (
-      this.siteSettings.discourse_subscriptions_campaign_amount_raised / 100
     );
   },
 

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -64,7 +64,7 @@ plugins:
     default: ""
   discourse_subscriptions_campaign_amount_raised:
     client: true
-    default: 0
+    default: 0.00
     hidden: true
   discourse_subscriptions_campaign_subscribers:
     client: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,3 +73,7 @@ plugins:
   discourse_subscriptions_campaign_group:
     default: ""
     hidden: true
+  discourse_subscriptions_campaign_goal_met:
+    client: true
+    default: false
+    hidden: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -73,11 +73,3 @@ plugins:
   discourse_subscriptions_campaign_group:
     default: ""
     hidden: true
-  discourse_subscriptions_campaign_goal_met:
-    client: true
-    default: false
-    hidden: true
-  discourse_subscriptions_campaign_goal_met_date:
-    client: true
-    default: ""
-    hidden: true

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -77,3 +77,7 @@ plugins:
     client: true
     default: false
     hidden: true
+  discourse_subscriptions_campaign_goal_met_date:
+    client: true
+    default: ""
+    hidden: true

--- a/plugin.rb
+++ b/plugin.rb
@@ -59,10 +59,14 @@ after_initialize do
   end
 
   add_to_serializer(:site, :show_campaign_banner) do
-    enabled = SiteSetting.discourse_subscriptions_enabled
-    campaign_enabled = SiteSetting.discourse_subscriptions_campaign_enabled
-    goal_met = Discourse.redis.get("subscriptions_goal_met_date")
+    begin
+      enabled = SiteSetting.discourse_subscriptions_enabled
+      campaign_enabled = SiteSetting.discourse_subscriptions_campaign_enabled
+      goal_met = Discourse.redis.get("subscriptions_goal_met_date")
 
-    enabled && campaign_enabled && (!goal_met || 7.days.ago <= Date.parse(goal_met))
+      enabled && campaign_enabled && (!goal_met || 7.days.ago <= Date.parse(goal_met))
+    rescue
+      false
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -57,4 +57,12 @@ after_initialize do
   Discourse::Application.routes.append do
     mount ::DiscourseSubscriptions::Engine, at: 's'
   end
+
+  add_to_serializer(:site, :show_campaign_banner) do
+    enabled = SiteSetting.discourse_subscriptions_enabled
+    campaign_enabled = SiteSetting.discourse_subscriptions_campaign_enabled
+    goal_met = Discourse.redis.get("subscriptions_goal_met_date")
+
+    enabled && campaign_enabled && (!goal_met || 7.days.ago <= Date.parse(goal_met))
+  end
 end

--- a/spec/serializers/site_serializer_spec.rb
+++ b/spec/serializers/site_serializer_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe SiteSerializer do
+  fab!(:user)  { Fabricate(:user) }
+  let(:guardian) { Guardian.new(user) }
+
+  before do
+    Discourse.redis.del("subscriptions_goal_met_date")
+    SiteSetting.discourse_subscriptions_enabled = true
+    SiteSetting.discourse_subscriptions_campaign_enabled = true
+  end
+  it 'is false if the goal_met date is < 7 days old' do
+    Discourse.redis.set('subscriptions_goal_met_date', 10.days.ago)
+    data = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+
+    expect(data[:show_campaign_banner]).to be false
+  end
+
+  it 'is true if the goal_met date is > 7 days old' do
+    Discourse.redis.set('subscriptions_goal_met_date', 1.days.ago)
+    data = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+
+    expect(data[:show_campaign_banner]).to be true
+  end
+
+  it 'fails gracefully if the goal_met date is invalid' do
+    Discourse.redis.set('subscriptions_goal_met_date', 'bananas')
+    data = described_class.new(Site.new(guardian), scope: guardian, root: false).as_json
+    expect(data[:show_campaign_banner]).to be false
+  end
+end

--- a/spec/services/campaign_spec.rb
+++ b/spec/services/campaign_spec.rb
@@ -41,6 +41,15 @@ describe DiscourseSubscriptions::Campaign do
           expect(SiteSetting.discourse_subscriptions_campaign_subscribers).to eq 1
           expect(SiteSetting.discourse_subscriptions_campaign_amount_raised).to eq 1000
         end
+
+        it "checks if the goal is completed or not" do
+          SiteSetting.discourse_subscriptions_campaign_goal = 5
+          ::Stripe::Subscription.expects(:list).returns(data: [subscription], has_more: false)
+
+          DiscourseSubscriptions::Campaign.new.refresh_data
+          expect(SiteSetting.discourse_subscriptions_campaign_goal_met).to be true
+          expect(SiteSetting.discourse_subscriptions_campaign_goal_met_date).to be_present
+        end
       end
 
       context "with a campaign product set" do
@@ -79,13 +88,6 @@ describe DiscourseSubscriptions::Campaign do
           expect(SiteSetting.discourse_subscriptions_campaign_amount_raised).to eq 833
         end
 
-        it "checks if the goal is completed or not" do
-          SiteSetting.discourse_subscriptions_campaign_goal = 5
-          ::Stripe::Subscription.expects(:list).returns(data: [subscription, campaign_subscription], has_more: false)
-
-          DiscourseSubscriptions::Campaign.new.refresh_data
-          expect(SiteSetting.discourse_subscriptions_campaign_goal_met).to be true
-        end
       end
     end
   end

--- a/spec/services/campaign_spec.rb
+++ b/spec/services/campaign_spec.rb
@@ -78,6 +78,14 @@ describe DiscourseSubscriptions::Campaign do
           expect(SiteSetting.discourse_subscriptions_campaign_subscribers).to eq 1
           expect(SiteSetting.discourse_subscriptions_campaign_amount_raised).to eq 833
         end
+
+        it "checks if the goal is completed or not" do
+          SiteSetting.discourse_subscriptions_campaign_goal = 5
+          ::Stripe::Subscription.expects(:list).returns(data: [subscription, campaign_subscription], has_more: false)
+
+          DiscourseSubscriptions::Campaign.new.refresh_data
+          expect(SiteSetting.discourse_subscriptions_campaign_goal_met).to be true
+        end
       end
     end
   end


### PR DESCRIPTION
To avoid banner fatigue with the campaigns feature, the plugin should hide the banner after the goal is completed. However, we also want the banner to show up if the goal dips below a certain percentage.

This PR adds this functionality based on two states:

- If we've met the goal, hide banner after 7 days.
- If we've dipped below 90% of goal (after the goal is met), show the banner again.

Implementation-wise, the calculation on the goal being met happens when the campaign update job runs every 30 minutes. We're storing the details in two new site settings (`_campaign_goal_met`, `_campaign_goal_met_date`), which are then used by the client to determine if the banner should be shown/hidden. 

Essentially, if the `_campaign_goal_met_date` setting is set, the client calculates if we're 7 days beyond the date value. If so, hide the banner. But if that setting is `nil`, show the banner based upon our normal conditions.

Two refactors in this PR:

1. Moved the `isGoalMet` calculation to the back end in the `campaign.rb` service vs. calculating on the front end. 
2. Moved the campaign price conversion from Stripe's format to float (i.e. `1000` to `10.00`) from the front end to the back end service.

Both refactors were done to avoid duplicate logic on front/back ends.