### PR TITLE
FIX: set interval field correctly in object root for recurring plans.

### DIFF
--- a/app/controllers/discourse_subscriptions/admin/plans_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/plans_controller.rb
@@ -55,9 +55,7 @@ module DiscourseSubscriptions
             trial_days = plan[:recurring][:trial_period_days]
           end
 
-          if plan[:recurring] && plan[:recurring][:interval]
-            interval = plan[:recurring][:interval]
-          end
+          interval = plan.dig(:recurring, :interval)
 
           serialized = plan.to_h.merge(trial_period_days: trial_days, currency: plan[:currency].upcase, interval: interval)
 

--- a/app/controllers/discourse_subscriptions/admin/plans_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/plans_controller.rb
@@ -55,7 +55,11 @@ module DiscourseSubscriptions
             trial_days = plan[:recurring][:trial_period_days]
           end
 
-          serialized = plan.to_h.merge(trial_period_days: trial_days, currency: plan[:currency].upcase)
+          if plan[:recurring] && plan[:recurring][:interval]
+            interval = plan[:recurring][:interval]
+          end
+
+          serialized = plan.to_h.merge(trial_period_days: trial_days, currency: plan[:currency].upcase, interval: interval)
 
           render_json_dump serialized
 

--- a/spec/requests/admin/plans_controller_spec.rb
+++ b/spec/requests/admin/plans_controller_spec.rb
@@ -79,9 +79,12 @@ module DiscourseSubscriptions
           end
 
           it "upcases the currency" do
-            ::Stripe::Price.expects(:retrieve).with('plan_12345').returns(currency: 'aud')
+            ::Stripe::Price.expects(:retrieve).with('plan_12345').returns(currency: 'aud', recurring: { interval: 'year' })
             get "/s/admin/plans/plan_12345.json"
-            expect(response.parsed_body["currency"]).to eq 'AUD'
+
+            plan = response.parsed_body
+            expect(plan["currency"]).to eq 'AUD'
+            expect(plan["interval"]).to eq 'year'
           end
         end
 


### PR DESCRIPTION
The interval field was missing in the Ember object since it was only available inside the nested object.