### PR TITLE
FIX: 500 error when editing a pricing plan

### DIFF
--- a/app/controllers/discourse_subscriptions/admin/plans_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/plans_controller.rb
@@ -55,7 +55,10 @@ module DiscourseSubscriptions
             trial_days = plan[:recurring][:trial_period_days]
           end
 
-          interval = plan.dig(:recurring, :interval)
+          interval = nil
+          if plan[:recurring] && plan[:recurring][:interval]
+            interval = plan[:recurring][:interval]
+          end
 
           serialized = plan.to_h.merge(trial_period_days: trial_days, currency: plan[:currency].upcase, interval: interval)
 


### PR DESCRIPTION
`.dig` isn't valid for stripe objects. This commit fixes this 500 error
you get when trying to edit a pricing plan:

```
NoMethodError (undefined method `dig' for #<Stripe::Price:0x....)
```