### PR TITLE
FIX: html strong tags showing

### DIFF
--- a/assets/javascripts/discourse/templates/components/campaign-banner.hbs
+++ b/assets/javascripts/discourse/templates/components/campaign-banner.hbs
@@ -64,7 +64,7 @@
         {{#if subscriberGoal}}
           <progress class="campaign-banner-progress-bar" value={{subscribers}} max={{siteSettings.discourse_subscriptions_campaign_goal}}/>
           <p class="campaign-banner-progress-description">
-            {{i18n "discourse_subscriptions.campaign.goal_comparison" current=subscribers goal=goalTarget}}
+            {{html-safe (i18n "discourse_subscriptions.campaign.goal_comparison" current=subscribers goal=goalTarget)}}
             {{i18n "discourse_subscriptions.campaign.subscribers"}}
           </p>
         {{else}}


### PR DESCRIPTION
We need to use the `html-safe` helper here so to that the html tags in
the translation template are rendered correctly.

See: https://meta.discourse.org/t/211376