### PR TITLE
FIX: Duplicate payments showing up in discourse UI

### DIFF
--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -23,7 +23,7 @@ module DiscourseSubscriptions
               invoice_ids = invoices_with_products.map { |invoice| invoice[:id] }
               payments = ::Stripe::PaymentIntent.list(customer: customer_id)
               payments_from_invoices = payments[:data].select { |payment| invoice_ids.include?(payment[:invoice]) }
-              data.concat(payments_from_invoices)
+              data = data | payments_from_invoices
             end
           end
 

--- a/spec/requests/user/payments_controller_spec.rb
+++ b/spec/requests/user/payments_controller_spec.rb
@@ -23,20 +23,44 @@ module DiscourseSubscriptions
         sign_in(user)
         Fabricate(:customer, customer_id: 'c_345678', user_id: user.id)
         Fabricate(:product, external_id: 'prod_8675309')
+        Fabricate(:product, external_id: 'prod_8675310')
       end
 
       it "gets payment intents" do
+        created_time = Time.now
         ::Stripe::Invoice.expects(:list).with(
           customer: 'c_345678'
         ).returns(
           data: [
-            id: "inv_900007",
-            lines: {
-              data: [
-                plan: {
-                  product: "prod_8675309"
-                }
-              ]
+            {
+              id: "inv_900007",
+              lines: {
+                data: [
+                  plan: {
+                    product: "prod_8675309"
+                  }
+                ]
+              }
+            },
+            {
+              id: "inv_900008",
+              lines: {
+                data: [
+                  plan: {
+                    product: "prod_8675310"
+                  }
+                ]
+              }
+            },
+            {
+              id: "inv_900008",
+              lines: {
+                data: [
+                  plan: {
+                    product: "prod_8675310"
+                  }
+                ]
+              }
             },
           ]
         )
@@ -46,10 +70,22 @@ module DiscourseSubscriptions
         ).returns(
           data: [
             {
+              id: "pi_900008",
+              invoice: "inv_900008",
+              created: created_time
+            },
+            {
+              id: "pi_900008",
+              invoice: "inv_900008",
+              created: created_time
+            },
+            {
+              id: "pi_900007",
               invoice: "inv_900007",
               created: Time.now
             },
             {
+              id: "pi_007",
               invoice: "inv_007",
               created: Time.now
             }
@@ -58,9 +94,11 @@ module DiscourseSubscriptions
 
         get "/s/user/payments.json"
 
-        invoice = response.parsed_body[0]["invoice"]
+        parsed_body = response.parsed_body
+        invoice = parsed_body[0]["invoice"]
 
         expect(invoice).to eq("inv_900007")
+        expect(parsed_body.count).to eq(2)
 
       end
 


### PR DESCRIPTION
Duplicate payments were showing up in the discourse ui for users. Actual
transactions in stripe were not being duplicated. This fix ensures that
when parsing the api response we don't append any duplicates. Added a
duplicate entry to the specs to test for this.

I do think there can be some improvements made to this controller
endpoint, but I'd like to save those for a different and larger PR and
just get this fix out first.
