### PR TITLE
FIX: Use primary color for StripeElement text

### DIFF
--- a/assets/stylesheets/common/subscribe.scss
+++ b/assets/stylesheets/common/subscribe.scss
@@ -26,6 +26,8 @@
   height: 40px;
   margin-bottom: 20px;
 
+  color: var(--primary);
+
   border: 1px solid var(--primary);
   background-color: var(--secondary);
 


### PR DESCRIPTION
I don't have a server to test this on unfortunately, but I believe this will fix this issue: https://meta.discourse.org/t/credit-card-placeholder-text-black-on-dark-theme/229684

Currently the input text in the StripeElement is black, rendering it unusable in dark mode. I think if we simply use the primary color variable for this it will take care of the issue.