### PR TITLE
DEV: Fix mocha deprecations

### DIFF
--- a/spec/requests/admin/coupons_controller_spec.rb
+++ b/spec/requests/admin/coupons_controller_spec.rb
@@ -23,7 +23,7 @@ module DiscourseSubscriptions
 
       describe "#index" do
         it "returns a list of promo codes" do
-          ::Stripe::PromotionCode.expects(:list).with(limit: 100).returns({
+          ::Stripe::PromotionCode.expects(:list).with({ limit: 100 }).returns({
           data: [{
               id: 'promo_123',
               coupon: {
@@ -38,7 +38,7 @@ module DiscourseSubscriptions
         end
 
         it "only returns valid promo codes" do
-          ::Stripe::PromotionCode.expects(:list).with(limit: 100).returns({
+          ::Stripe::PromotionCode.expects(:list).with({ limit: 100 }).returns({
           data: [{
               id: 'promo_123',
               coupon: {

--- a/spec/requests/admin/plans_controller_spec.rb
+++ b/spec/requests/admin/plans_controller_spec.rb
@@ -66,7 +66,7 @@ module DiscourseSubscriptions
           end
 
           it "lists the plans for the product" do
-            ::Stripe::Price.expects(:list).with(product: 'prod_id123')
+            ::Stripe::Price.expects(:list).with({ product: 'prod_id123' })
             get "/s/admin/plans.json", params: { product_id: 'prod_id123' }
           end
         end

--- a/spec/requests/admin/subscriptions_controller_spec.rb
+++ b/spec/requests/admin/subscriptions_controller_spec.rb
@@ -134,7 +134,7 @@ module DiscourseSubscriptions
             )
           ::Stripe::Subscription.expects(:retrieve).with('sub_12345').returns(latest_invoice: 'in_123')
           ::Stripe::Invoice.expects(:retrieve).with('in_123').returns(payment_intent: 'pi_123')
-          ::Stripe::Refund.expects(:create).with(payment_intent: 'pi_123')
+          ::Stripe::Refund.expects(:create).with({ payment_intent: 'pi_123' })
 
           delete "/s/admin/subscriptions/sub_12345.json", params: { refund: true }
         end

--- a/spec/requests/subscribe_controller_spec.rb
+++ b/spec/requests/subscribe_controller_spec.rb
@@ -42,7 +42,7 @@ module DiscourseSubscriptions
       describe "#index" do
 
         it "gets products" do
-          ::Stripe::Product.expects(:list).with(ids: product_ids, active: true).returns(data: [product])
+          ::Stripe::Product.expects(:list).with({ ids: product_ids, active: true }).returns(data: [product])
 
           get "/s.json"
 
@@ -57,7 +57,7 @@ module DiscourseSubscriptions
 
         it "is subscribed" do
           Fabricate(:customer, product_id: product[:id], user_id: user.id, customer_id: 'x')
-          ::Stripe::Product.expects(:list).with(ids: product_ids, active: true).returns(data: [product])
+          ::Stripe::Product.expects(:list).with({ ids: product_ids, active: true }).returns(data: [product])
 
           get "/s.json"
           data = response.parsed_body
@@ -66,7 +66,7 @@ module DiscourseSubscriptions
 
         it "is not subscribed" do
           ::DiscourseSubscriptions::Customer.delete_all
-          ::Stripe::Product.expects(:list).with(ids: product_ids, active: true).returns(data: [product])
+          ::Stripe::Product.expects(:list).with({ ids: product_ids, active: true }).returns(data: [product])
 
           get "/s.json"
           data = response.parsed_body


### PR DESCRIPTION
It now supports strict keyword argument matching by default.