### PR TITLE
FEATURE: Skip product listing if only one product is present

### DIFF
--- a/assets/javascripts/discourse/routes/subscribe-index.js
+++ b/assets/javascripts/discourse/routes/subscribe-index.js
@@ -5,4 +5,19 @@ export default Route.extend({
   model() {
     return Product.findAll();
   },
+
+  afterModel(products) {
+    if (products.length === 1) {
+      const product = products[0];
+
+      if (this.currentUser && product.subscribed && !product.repurchaseable) {
+        this.transitionTo(
+          "user.billing.subscriptions",
+          this.currentUser.username
+        );
+      } else {
+        this.transitionTo("subscribe.show", product.id);
+      }
+    }
+  },
 });

--- a/test/javascripts/acceptance/subscribe-test.js
+++ b/test/javascripts/acceptance/subscribe-test.js
@@ -2,6 +2,22 @@ import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
 import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
 import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
+import pretender, { response } from "discourse/tests/helpers/create-pretender";
+
+function singleProductPretender() {
+  pretender.get("/s", () => {
+    const products = [
+      {
+        id: "prod_23o8I7tU4g56",
+        name: "Awesome Product",
+        description:
+          "Subscribe to our awesome product. For only $230.10 per month, you can get access. This is a test site. No real credit card transactions.",
+      },
+    ];
+
+    return response(products);
+  });
+}
 
 acceptance("Discourse Subscriptions", function (needs) {
   needs.user();
@@ -22,5 +38,15 @@ acceptance("Discourse Subscriptions", function (needs) {
       count(".subscribe-buttons button") > 0,
       "has buttons for subscribe"
     );
+  });
+
+  test("skips products list on sites with one product", async function (assert) {
+    singleProductPretender();
+
+    await visit("/s");
+
+    assert.dom(".subscribe-buttons button").exists({ count: 1 });
+    assert.dom("input.subscribe-promo-code").exists();
+    assert.dom("button.btn-payment").exists();
   });
 });


### PR DESCRIPTION
At the moment, paying for a product typically involves first clicking the subscribe link added to the navigation bar, selecting a product and then adding card details to to make the purchase.

This change skips the product selection step if the site has only one product.