### PR TITLE
DEV: remove old shadow definition

### DIFF
--- a/assets/stylesheets/common/subscribe.scss
+++ b/assets/stylesheets/common/subscribe.scss
@@ -37,7 +37,6 @@
 
 .StripeElement--focus {
   border-color: var(--tertiary);
-  box-shadow: shadow("focus");
   outline: 1px solid var(--tertiary);
 }
 


### PR DESCRIPTION
We no longer use the "focus" shadow in core, this removes it. The border color should be sufficient here and follows some core patterns. 