### PR TITLE
DEV: Fixes SCSS deprecation in console

### DIFF
--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -314,11 +314,15 @@ html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
 
 $particles: 50;
 $width: 500;
+$halfwidth: $width / 2;
 $height: 250;
+$heightpartial: $height / 1.2;
 
 $sidebar-particles: 25;
 $sidebar-width: 300;
+$sidebar-half-width: $sidebar-width / 2;
 $sidebar-height: 100;
+$sidebar-height-partial: $sidebar-height / 1.2;
 
 // Create the explosion...
 $box-shadow: ();
@@ -329,11 +333,11 @@ $sidebar-box-shadow2: ();
 
 @for $i from 0 through $particles {
   $box-shadow: $box-shadow,
-    random($width)-$width /
-      2 +
+    random($width) -
+      $halfwidth +
       px
-      random($height)-$height /
-      1.2 +
+      random($height) -
+      $heightpartial +
       px
       hsl(random(360), 100, 50);
   $box-shadow2: $box-shadow2, 0 0 #fff;
@@ -341,11 +345,11 @@ $sidebar-box-shadow2: ();
 
 @for $i from 0 through $sidebar-particles {
   $sidebar-box-shadow: $sidebar-box-shadow,
-    random($sidebar-width)-$sidebar-width /
-      2 +
+    random($sidebar-width) -
+      $sidebar-half-width +
       px
-      random($sidebar-height)-$sidebar-height /
-      1.2 +
+      random($sidebar-height) -
+      $sidebar-height-partial +
       px
       hsl(random(360), 100, 50);
   $sidebar-box-shadow2: $sidebar-box-shadow2, 0 0 #fff;

--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -305,7 +305,7 @@ html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
   }
 }
 
-/* Fireworks
+/* Fireworks (modified to fit modern SASS standards)
   Copyright (c) 2020 by Eddie Lin (https://codepen.io/yshlin/pen/ylDEk)
   Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
   The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.


### PR DESCRIPTION
Sample warning was:

```
Using / for division outside of calc() is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($sidebar-height, 1.2) or calc($sidebar-height / 1.2)

More info and automated migrator: https://sass-lang.com/d/slash-div
```