### PR TITLE
DEV: Change settings root from plugins: to discourse_subscriptions

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -1,4 +1,9 @@
 en:
+  admin_js:
+    admin:
+      site_settings:
+        categories:
+          discourse_subscriptions: "Discourse Subscriptions"
   site_settings:
     discourse_subscriptions_enabled: Enable the Discourse Subscriptions plugin.
     discourse_subscriptions_extra_nav_subscribe: Show the subscribe button in the primary navigation

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,4 +1,4 @@
-plugins:
+discourse_subscriptions:
   discourse_subscriptions_enabled:
     default: false
   discourse_subscriptions_extra_nav_subscribe:


### PR DESCRIPTION
This is so the plugins settings are better categorized in the site settings UI.