### PR TITLE
UX: Surface stripe AuthenticationError on the Admin Dashboard

### DIFF
--- a/app/controllers/concerns/stripe.rb
+++ b/app/controllers/concerns/stripe.rb
@@ -4,6 +4,8 @@ module DiscourseSubscriptions
   module Stripe
     extend ActiveSupport::Concern
 
+    AUTH_PROBLEM_IDENTIFIER = "#{DiscourseSubscriptions::PLUGIN_NAME}.stripe_auth_error"
+
     def set_api_key
       ::Stripe.api_key = SiteSetting.discourse_subscriptions_secret_key
     end

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -4,3 +4,5 @@ en:
     card:
       declined: Card Declined
       invalid: Card Invalid
+    auth:
+      invalid: Invalid Credentials for Stripe. Please check your <a href="%{settingsUrl}" target="_blank">discourse-subscriptions settings</a>.

--- a/plugin.rb
+++ b/plugin.rb
@@ -27,6 +27,10 @@ extend_content_security_policy(script_src: %w[https://js.stripe.com/v3/ https://
 
 add_admin_route "discourse_subscriptions.admin_navigation", "discourse-subscriptions.products"
 
+module ::DiscourseSubscriptions
+  PLUGIN_NAME = "discourse-subscriptions"
+end
+
 Discourse::Application.routes.append do
   get "/admin/plugins/discourse-subscriptions" => "admin/plugins#index",
       :constraints => AdminConstraint.new


### PR DESCRIPTION
There's a bit of log noise now when a user has an invalid API key.

```
Job exception: (Status 401) Invalid API Key provided: isoa_wi******************moOs
```

This surfaces the issue to the admin dashboard instead of just /logs. AdminProblemChecks are done every 10.minutes, so we won't have to worry about the `Problem` still being there if the plugin is removed.