### PR TITLE
FIX: Ensure deletion of product upon confirmation

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-index.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-index.hbs
@@ -56,7 +56,7 @@
 
                 <DButton
                   @action={{route-action "destroyProduct"}}
-                  @actionParam="product"
+                  @actionParam={{product}}
                   @icon="trash-alt"
                   class="btn-danger btn no-text btn-icon"
                 />

--- a/spec/fabricators/customer_fabricator.rb
+++ b/spec/fabricators/customer_fabricator.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Fabricator(:product, from: "DiscourseSubscriptions::Product")
+Fabricator(:customer, from: "DiscourseSubscriptions::Customer")

--- a/spec/fabricators/product_fabricator.rb
+++ b/spec/fabricators/product_fabricator.rb
@@ -1,3 +1,3 @@
 # frozen_string_literal: true
 
-Fabricator(:customer, from: "DiscourseSubscriptions::Customer")
+Fabricator(:product, from: "DiscourseSubscriptions::Product")

--- a/spec/system/page_objects/admin_subscription_product.rb
+++ b/spec/system/page_objects/admin_subscription_product.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module PageObjects
+  module Pages
+    class AdminSubscriptionProduct < PageObjects::Pages::Base
+      PRODUCTS_TABLE_SELECTOR = "table.discourse-patrons-table"
+
+      def visit_products
+        visit("/admin/plugins/discourse-subscriptions/products")
+        self
+      end
+
+      def has_product?(name)
+        has_css?("table.discourse-patrons-table tr", text: name)
+        self
+      end
+
+      def has_number_of_products?(count)
+        has_css?("table.discourse-patrons-table tr", count:)
+        self
+      end
+
+      def click_trash_nth_row(row)
+        find("table.discourse-patrons-table tr:nth-child(#{row}) button.btn-danger").click()
+      end
+    end
+  end
+end

--- a/spec/system/subscription_product_spec.rb
+++ b/spec/system/subscription_product_spec.rb
@@ -21,15 +21,15 @@ describe "Subscription products", type: :system do
     expect(page).to have_css(".modal-container .login-modal")
   end
 
-  it "shows products on the products  and allows deletion" do
+  it "shows products on the products and allows deletion" do
     # this needs to be stubbed or it will try to make a request to stripe
-    ::Stripe::Product.stubs(:list).returns({ data: [{ id: "prod_OiK", active: true, name: "Tomtom" }] })
-    ::Stripe::Product.stubs(:delete).returns({"id":"prod_OiK"})
+    ::Stripe::Product.stubs(:list).returns(
+      { data: [{ id: "prod_OiK", active: true, name: "Tomtom" }] },
+    )
+    ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
     sign_in(admin)
 
-    product_subscriptions_page
-      .visit_products
-      .has_product?("Tomtom")
+    product_subscriptions_page.visit_products.has_product?("Tomtom")
 
     product_subscriptions_page.click_trash_nth_row(1)
     dialog.click_yes

--- a/spec/system/subscription_product_spec.rb
+++ b/spec/system/subscription_product_spec.rb
@@ -12,11 +12,20 @@ describe "Subscription products", type: :system do
     SiteSetting.discourse_subscriptions_secret_key = "sk_test_51xuu"
     SiteSetting.discourse_subscriptions_public_key = "pk_test_51xuu"
 
-    # this needs to be stubbed or it will try to make a request to stripe
-    ::Stripe::Product.stubs(:list).returns(
-      { data: [{ id: "prod_OiK", active: true, name: "Tomtom" }] },
-    )
+    # # this needs to be stubbed or it will try to make a request to stripe
+    one_product = {
+      id: "prod_OiK",
+      active: true,
+      name: "Tomtom",
+      metadata: {
+        description: "Photos of tomtom",
+        repurchaseable: true,
+      },
+    }
+    ::Stripe::Product.stubs(:list).returns({ data: [one_product] })
     ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
+    ::Stripe::Product.stubs(:retrieve).returns(one_product)
+    ::Stripe::Price.stubs(:list).returns({ data: [] })
   end
 
   it "shows the login modal" do

--- a/spec/system/subscription_product_spec.rb
+++ b/spec/system/subscription_product_spec.rb
@@ -2,9 +2,16 @@
 
 describe "Subscription products", type: :system do
   fab!(:admin)
-  fab!(:product) { Fabricate(:product, external_id: "prod_OiKyO6ZMFCIhQa") }
+  fab!(:product) { Fabricate(:product, external_id: "prod_OiK") }
+  let(:dialog) { PageObjects::Components::Dialog.new }
+  let(:product_subscriptions_page) { PageObjects::Pages::AdminSubscriptionProduct.new }
 
-  before { SiteSetting.discourse_subscriptions_enabled = true }
+  before do
+    SiteSetting.discourse_subscriptions_enabled = true
+
+    SiteSetting.discourse_subscriptions_secret_key = "sk_test_51xuu"
+    SiteSetting.discourse_subscriptions_public_key = "pk_test_51xuu"
+  end
 
   it "shows the login modal" do
     visit("/s")
@@ -12,5 +19,21 @@ describe "Subscription products", type: :system do
     find("button.login-required.subscriptions").click
 
     expect(page).to have_css(".modal-container .login-modal")
+  end
+
+  it "shows products on the products  and allows deletion" do
+    # this needs to be stubbed or it will try to make a request to stripe
+    ::Stripe::Product.stubs(:list).returns({ data: [{ id: "prod_OiK", active: true, name: "Tomtom" }] })
+    ::Stripe::Product.stubs(:delete).returns({"id":"prod_OiK"})
+    sign_in(admin)
+
+    product_subscriptions_page
+      .visit_products
+      .has_product?("Tomtom")
+
+    product_subscriptions_page.click_trash_nth_row(1)
+    dialog.click_yes
+
+    product_subscriptions_page.has_number_of_products?(0)
   end
 end

--- a/spec/system/subscription_product_spec.rb
+++ b/spec/system/subscription_product_spec.rb
@@ -11,6 +11,12 @@ describe "Subscription products", type: :system do
 
     SiteSetting.discourse_subscriptions_secret_key = "sk_test_51xuu"
     SiteSetting.discourse_subscriptions_public_key = "pk_test_51xuu"
+
+    # this needs to be stubbed or it will try to make a request to stripe
+    ::Stripe::Product.stubs(:list).returns(
+      { data: [{ id: "prod_OiK", active: true, name: "Tomtom" }] },
+    )
+    ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
   end
 
   it "shows the login modal" do
@@ -22,11 +28,6 @@ describe "Subscription products", type: :system do
   end
 
   it "shows products on the products and allows deletion" do
-    # this needs to be stubbed or it will try to make a request to stripe
-    ::Stripe::Product.stubs(:list).returns(
-      { data: [{ id: "prod_OiK", active: true, name: "Tomtom" }] },
-    )
-    ::Stripe::Product.stubs(:delete).returns({ id: "prod_OiK" })
     sign_in(admin)
 
     product_subscriptions_page.visit_products.has_product?("Tomtom")


### PR DESCRIPTION
Regression from https://github.com/discourse/discourse-subscriptions/pull/158, where we were passing in `"product"` instead of `{{product}}`.

This commit ensures that the `product` item is passed in when deleting the product.