### PR TITLE
FIX: Translation missing for Norway

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -298,7 +298,7 @@ en:
           NU: "Niue"
           NF: "Norfolk Island"
           MP: "Northern Mariana Islands"
-          NO: "Norway"
+          "NO": "Norway"
           OM: "Oman"
           PK: "Pakistan"
           PW: "Palau"

--- a/test/javascripts/acceptance/subscribe-test.js
+++ b/test/javascripts/acceptance/subscribe-test.js
@@ -3,7 +3,7 @@ import { test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
 import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
-import { i18n } from "I18n";
+import { I18n } from "I18n";
 
 function singleProductPretender() {
   pretender.get("/s", () => {
@@ -52,6 +52,9 @@ acceptance("Discourse Subscriptions", function (needs) {
   });
 
   test("Norway is translated correctly", async function (assert) {
-    assert.equal(I18n.t("en.discourse_subscriptions.subscribe.countries.NO"), "Norway");
+    assert.equal(
+      I18n.t("en.discourse_subscriptions.subscribe.countries.NO"),
+      "Norway"
+    );
   });
 });

--- a/test/javascripts/acceptance/subscribe-test.js
+++ b/test/javascripts/acceptance/subscribe-test.js
@@ -3,6 +3,7 @@ import { test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
 import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
+import { i18n } from "I18n";
 
 function singleProductPretender() {
   pretender.get("/s", () => {
@@ -48,5 +49,9 @@ acceptance("Discourse Subscriptions", function (needs) {
     assert.dom(".subscribe-buttons button").exists({ count: 1 });
     assert.dom("input.subscribe-promo-code").exists();
     assert.dom("button.btn-payment").exists();
+  });
+
+  test("Norway is translated correctly", async function (assert) {
+    assert.equal(I18n.t("en.discourse_subscriptions.subscribe.countries.NO"), "Norway");
   });
 });

--- a/test/javascripts/acceptance/subscribe-test.js
+++ b/test/javascripts/acceptance/subscribe-test.js
@@ -2,6 +2,7 @@ import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
+import I18n from "discourse-i18n";
 import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
 
 function singleProductPretender() {

--- a/test/javascripts/acceptance/subscribe-test.js
+++ b/test/javascripts/acceptance/subscribe-test.js
@@ -2,8 +2,8 @@ import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
-import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
 import { I18n } from "I18n";
+import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
 
 function singleProductPretender() {
   pretender.get("/s", () => {

--- a/test/javascripts/acceptance/subscribe-test.js
+++ b/test/javascripts/acceptance/subscribe-test.js
@@ -2,7 +2,6 @@ import { click, visit } from "@ember/test-helpers";
 import { test } from "qunit";
 import pretender, { response } from "discourse/tests/helpers/create-pretender";
 import { acceptance, count } from "discourse/tests/helpers/qunit-helpers";
-import { I18n } from "I18n";
 import { stubStripe } from "discourse/plugins/discourse-subscriptions/helpers/stripe";
 
 function singleProductPretender() {
@@ -51,10 +50,16 @@ acceptance("Discourse Subscriptions", function (needs) {
     assert.dom("button.btn-payment").exists();
   });
 
+  // In YAML `NO:` is a boolean, so we need quotes around `"NO":`.
   test("Norway is translated correctly", async function (assert) {
     assert.equal(
-      I18n.t("en.discourse_subscriptions.subscribe.countries.NO"),
+      I18n.t("discourse_subscriptions.subscribe.countries.NO"),
       "Norway"
+    );
+
+    assert.equal(
+      I18n.t("discourse_subscriptions.subscribe.countries.NG"),
+      "Nigeria"
     );
   });
 });


### PR DESCRIPTION
Turns out in YAML `NO` is interpreted as a boolean value, so we need to
wrap it in quotes.
