### PR TITLE
FIX: Allow active status for updated webhook

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -64,6 +64,11 @@ module DiscourseSubscriptions
         )
       when "customer.subscription.created"
       when "customer.subscription.updated"
+        status = event[:data][:object][:status]
+        if !["complete", "active"].include?(status)
+          return head 200
+        end
+
         customer =
           Customer.find_by(
             customer_id: event[:data][:object][:customer],
@@ -71,7 +76,6 @@ module DiscourseSubscriptions
           )
 
         return render_json_error "customer not found" if !customer
-        return head 200 if event[:data][:object][:status] != "complete"
 
         user = ::User.find_by(id: customer.user_id)
         return render_json_error "user not found" if !user

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -204,6 +204,14 @@ RSpec.describe DiscourseSubscriptions::HooksController do
 
           expect(response.status).to eq 200
         end
+
+        it "adds the user to the group when status is active" do
+          event_data[:object][:status] = "active"
+
+          expect { post "/s/hooks.json" }.to change { user.groups.count }.by(1)
+
+          expect(response.status).to eq 200
+        end
       end
     end
 


### PR DESCRIPTION
Likely there was an API change at some point now that we are using the
latest version of the stripe API. When the
`customer.subscription.updated` webhook is called we should also accept
the status of "active".
