### PR TITLE
FIX: Update cc save button missing

### DIFF
--- a/assets/javascripts/discourse/templates/user/billing/subscriptions/card.hbs
+++ b/assets/javascripts/discourse/templates/user/billing/subscriptions/card.hbs
@@ -12,6 +12,5 @@
     @action={{action "updatePaymentMethod"}}
     @saved={{saved}}
     @saveDisabled={{loading}}
-    @savingText="discourse_subscriptions.user.subscriptions.update_card.single"
   />
 </div>


### PR DESCRIPTION
The save button for a user to update their cc was missing.

Looks like we can't override the computed property `savingText`. This
was causing the form to break. Likely was a change in core sometime ago.
