### PR TITLE
FIX: Auto-Create Support Campaign button

### DIFF
--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions.hbs
@@ -14,7 +14,7 @@
           @label="discourse_subscriptions.campaign.one_click_campaign"
           @icon="plus-square"
           @action={{action "createOneClickCampaign"}}
-          @isLoading="loading"
+          @isLoading={{loading}}
         />
       {{/unless}}
     {{/if}}


### PR DESCRIPTION
The Auto-Create Support Campaign button was just showing an infinite "is
loading" spinner so you couldn't even click on it.

This fix allows the button to work again and only show the loading
spinner when it is actually loading.

See: https://meta.discourse.org/t/discourse-subscriptions/140818/653?u=blake

![image](https://github.com/discourse/discourse-subscriptions/assets/1490496/61cdce2a-5cf3-4ffd-91d5-8ce928ceb343)

