### PR TITLE
FIX: Login required for Stripe Checkout

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -34,10 +34,13 @@ module DiscourseSubscriptions
 
         return head 200 if checkout_session[:status] != "complete"
         return render_json_error "customer not found" if checkout_session[:customer].nil?
+        return render_json_error "email not found" if !email
 
         customer_id = checkout_session[:customer]
 
         user = ::User.find_by_username_or_email(email)
+
+        return render_json_error "customer not found" if !user
 
         discourse_customer = Customer.create(user_id: user.id, customer_id: customer_id)
 

--- a/assets/javascripts/discourse/templates/subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/subscriptions.hbs
@@ -1,3 +1,7 @@
 <div class="container">
-  {{pricingTable}}
+  {{#if currentUser}}
+    {{pricingTable}}
+  {{else}}
+    <LoginRequired />
+  {{/if}}
 </div>

--- a/assets/javascripts/discourse/templates/subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/subscriptions.hbs
@@ -1,6 +1,6 @@
 <div class="container">
-  {{#if currentUser}}
-    {{pricingTable}}
+  {{#if this.currentUser}}
+    {{this.pricingTable}}
   {{else}}
     <LoginRequired />
   {{/if}}

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -184,6 +184,44 @@ RSpec.describe DiscourseSubscriptions::HooksController do
       end
     end
 
+    describe "checkout.session.completed with anonymous user" do
+      before do
+        checkout_session_completed_bad_data[:object][:customer_email] = "anonymous@example.com"
+        data = checkout_session_completed_bad_data
+        event = { type: "checkout.session.completed", data: data }
+        ::Stripe::Checkout::Session
+          .stubs(:list_line_items)
+          .with(checkout_session_completed_data[:object][:id], { limit: 1 })
+          .returns(list_line_items_data)
+
+        ::Stripe::Webhook.stubs(:construct_event).returns(event)
+      end
+
+      it "is returns 422" do
+        post "/s/hooks.json"
+        expect(response.status).to eq 422
+      end
+    end
+
+    describe "checkout.session.completed with no customer email" do
+      before do
+        checkout_session_completed_bad_data[:object][:customer_email] = nil
+        data = checkout_session_completed_bad_data
+        event = { type: "checkout.session.completed", data: data }
+        ::Stripe::Checkout::Session
+          .stubs(:list_line_items)
+          .with(checkout_session_completed_data[:object][:id], { limit: 1 })
+          .returns(list_line_items_data)
+
+        ::Stripe::Webhook.stubs(:construct_event).returns(event)
+      end
+
+      it "is returns 422" do
+        post "/s/hooks.json"
+        expect(response.status).to eq 422
+      end
+    end
+
     describe "customer.subscription.updated" do
       before do
         event = { type: "customer.subscription.updated", data: event_data }

--- a/spec/system/pricing_table_spec.rb
+++ b/spec/system/pricing_table_spec.rb
@@ -7,7 +7,6 @@ RSpec.describe "Pricing Table", type: :system, js: true do
   let(:product_subscriptions_page) { PageObjects::Pages::AdminSubscriptionProduct.new }
 
   before do
-    sign_in(admin)
     SiteSetting.discourse_subscriptions_enabled = true
     SiteSetting.discourse_subscriptions_extra_nav_subscribe = true
 
@@ -33,6 +32,7 @@ RSpec.describe "Pricing Table", type: :system, js: true do
   end
 
   it "Links to the pricing table page" do
+    sign_in(admin)
     visit("/")
 
     link = find("li.nav-item_subscribe a")
@@ -41,6 +41,7 @@ RSpec.describe "Pricing Table", type: :system, js: true do
   end
 
   it "Links to the old page when disabled" do
+    sign_in(admin)
     SiteSetting.discourse_subscriptions_pricing_table_enabled = false
     visit("/")
 
@@ -50,6 +51,7 @@ RSpec.describe "Pricing Table", type: :system, js: true do
   end
 
   it "Old subscribe page still works when disabled" do
+    sign_in(admin)
     SiteSetting.discourse_subscriptions_pricing_table_enabled = false
     visit("/")
 
@@ -58,6 +60,7 @@ RSpec.describe "Pricing Table", type: :system, js: true do
   end
 
   it "Shows a message when not setup yet" do
+    sign_in(admin)
     visit("/")
 
     find("li.nav-item_subscribe a").click
@@ -65,6 +68,17 @@ RSpec.describe "Pricing Table", type: :system, js: true do
     expect(page).to have_selector(
       "div.container",
       text: "There are currently no products available.",
+    )
+  end
+
+  it "Shows a log in message if not signed in" do
+    visit("/")
+
+    find("li.nav-item_subscribe a").click
+
+    expect(page).to have_selector(
+      "div.container",
+      text: "Log in or create an account to subscribe.",
     )
   end
 end


### PR DESCRIPTION
If an anonymous user tries to subscribe we need to show them a log in
message first. We currently don't have support for anonymous
subscriptions.

Follow up to: 45754baa0070f1fe600f4fd71d2d46e61d359b13
