### PR TITLE
FIX: One-time purchase pending invoice item

### DIFF
--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -100,16 +100,18 @@ module DiscourseSubscriptions
         else
           coupon_id = promo_code[:coupon][:id] if promo_code && promo_code[:coupon] &&
             promo_code[:coupon][:id]
+          invoice = ::Stripe::Invoice.create(customer: customer[:id])
           invoice_item =
             ::Stripe::InvoiceItem.create(
               customer: customer[:id],
               price: params[:plan],
               discounts: [{ coupon: coupon_id }],
+              invoice: invoice[:id],
             )
-          invoice = ::Stripe::Invoice.create(customer: customer[:id])
           transaction = ::Stripe::Invoice.finalize_invoice(invoice[:id])
           payment_intent = retrieve_payment_intent(transaction[:id]) if transaction[:status] ==
             "open"
+          return render_json_error "error completing transaction" if payment_intent.nil?
           transaction = ::Stripe::Invoice.pay(invoice[:id]) if payment_intent[:status] ==
             "successful"
         end

--- a/app/controllers/discourse_subscriptions/subscribe_controller.rb
+++ b/app/controllers/discourse_subscriptions/subscribe_controller.rb
@@ -111,7 +111,11 @@ module DiscourseSubscriptions
           transaction = ::Stripe::Invoice.finalize_invoice(invoice[:id])
           payment_intent = retrieve_payment_intent(transaction[:id]) if transaction[:status] ==
             "open"
-          return render_json_error "error completing transaction" if payment_intent.nil?
+          if payment_intent.nil?
+            return(
+              render_json_error I18n.t("js.discourse_subscriptions.subscribe.transaction_error")
+            )
+          end
           transaction = ::Stripe::Invoice.pay(invoice[:id]) if payment_intent[:status] ==
             "successful"
         end

--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -45,8 +45,10 @@ module DiscourseSubscriptions
         invoices_with_products =
           all_invoices[:data].select do |invoice|
             invoice_lines = invoice[:lines][:data][0] if invoice[:lines] && invoice[:lines][:data]
-            invoice_product_id = parse_invoice_lines(invoice_lines)
-            product_ids.include?(invoice_product_id)
+            if invoice_lines
+              invoice_product_id = parse_invoice_lines(invoice_lines)
+              product_ids.include?(invoice_product_id)
+            end
           end
       end
 


### PR DESCRIPTION
This change ensures we attach the invoice item to the invoice to avoid
any occurrences of an empty invoice being paid with pending invoice
items.
