### PR TITLE
FIX: Campaign banner should link to pricing table when enabled

### DIFF
--- a/assets/javascripts/discourse/components/campaign-banner.hbs
+++ b/assets/javascripts/discourse/components/campaign-banner.hbs
@@ -36,7 +36,7 @@
           </LinkTo>
         {{else}}
           <LinkTo
-            @route="subscribe"
+            @route={{this.subscribeRoute}}
             class="btn btn-primary campaign-banner-info-button"
           >
             {{d-icon "far-heart"}}

--- a/assets/javascripts/discourse/components/campaign-banner.js
+++ b/assets/javascripts/discourse/components/campaign-banner.js
@@ -173,7 +173,7 @@ export default Component.extend({
     if (this.pricingTableEnabled) {
       return "subscriptions";
     }
-    return "subscribe"
+    return "subscribe";
   },
 
   @discourseComputed

--- a/assets/javascripts/discourse/components/campaign-banner.js
+++ b/assets/javascripts/discourse/components/campaign-banner.js
@@ -32,6 +32,7 @@ export default Component.extend({
   amountRaised: setting("discourse_subscriptions_campaign_amount_raised"),
   goalTarget: setting("discourse_subscriptions_campaign_goal"),
   product: setting("discourse_subscriptions_campaign_product"),
+  pricingTableEnabled: setting("discourse_subscriptions_pricing_table_enabled"),
   showContributors: setting(
     "discourse_subscriptions_campaign_show_contributors"
   ),
@@ -126,7 +127,8 @@ export default Component.extend({
     const showOnRoute =
       currentRoute !== "discovery.s" &&
       !currentRoute.split(".")[0].includes("admin") &&
-      currentRoute.split(".")[0] !== "subscribe";
+      currentRoute.split(".")[0] !== "subscribe" &&
+      currentRoute.split(".")[0] !== "subscriptions";
 
     if (!this.site.show_campaign_banner) {
       return false;
@@ -164,6 +166,14 @@ export default Component.extend({
       (!dismissedBannerKey || now - bannerDismissedTime > threeMonths) &&
       !dismissed
     );
+  },
+
+  @discourseComputed
+  subscribeRoute() {
+    if (this.pricingTableEnabled) {
+      return "subscriptions";
+    }
+    return "subscribe"
   },
 
   @discourseComputed

--- a/spec/system/pricing_table_spec.rb
+++ b/spec/system/pricing_table_spec.rb
@@ -40,12 +40,33 @@ RSpec.describe "Pricing Table", type: :system, js: true do
     expect(uri.path).to eq("/s/subscriptions")
   end
 
+  it "Links to the pricing table page from the campaign banner" do
+    sign_in(admin)
+    SiteSetting.discourse_subscriptions_campaign_enabled = true
+    visit("/")
+
+    link = find(".campaign-banner-info-button")
+    uri = URI.parse(link[:href])
+    expect(uri.path).to eq("/s/subscriptions")
+  end
+
   it "Links to the old page when disabled" do
     sign_in(admin)
     SiteSetting.discourse_subscriptions_pricing_table_enabled = false
     visit("/")
 
     link = find("li.nav-item_subscribe a")
+    uri = URI.parse(link[:href])
+    expect(uri.path).to eq("/s")
+  end
+
+  it "Links to the old page from the campaign banner when disabled" do
+    sign_in(admin)
+    SiteSetting.discourse_subscriptions_pricing_table_enabled = false
+    SiteSetting.discourse_subscriptions_campaign_enabled = true
+    visit("/")
+
+    link = find(".campaign-banner-info-button")
     uri = URI.parse(link[:href])
     expect(uri.path).to eq("/s")
   end


### PR DESCRIPTION
If the new pricing table is enabled the campaign banner should link to
the pricing table route.
