### PR TITLE
FIX: Add missing transaction error translation

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -116,6 +116,7 @@ en:
         invalid_cardholder_country: Country is required.
         invalid_cardholder_state: State is required.
         invalid_cardholder_province: Province is required.
+        transaction_error: There was an error processing the payment. Please try again.
         card:
           title: Payment
         customer:


### PR DESCRIPTION
### What is this change?

I am trying to enable `i18n.raise_on_missing_translations` in core. It caught a missing translation in this plugin.