### PR TITLE
FIX: Admins unable to cancel a subscription for a user

### DIFF
--- a/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
@@ -98,7 +98,6 @@ module DiscourseSubscriptions
         payment_intent = invoice[:payment_intent] if invoice[:payment_intent]
         refund = ::Stripe::Refund.create({ payment_intent: payment_intent })
       end
-
     end
   end
 end

--- a/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
+++ b/app/controllers/discourse_subscriptions/admin/subscriptions_controller.rb
@@ -53,7 +53,7 @@ module DiscourseSubscriptions
         params.require(:id)
         begin
           refund_subscription(params[:id]) if params[:refund]
-          subscription = ::Stripe::Subscription.delete(params[:id])
+          subscription = ::Stripe::Subscription.cancel(params[:id])
 
           customer =
             Customer.find_by(
@@ -61,11 +61,8 @@ module DiscourseSubscriptions
               customer_id: subscription[:customer],
             )
 
-          Subscription.delete_by(external_id: params[:id])
-
           if customer
             user = ::User.find(customer.user_id)
-            customer.delete
             group = plan_group(subscription[:plan])
             group.remove(user) if group
           end
@@ -101,6 +98,7 @@ module DiscourseSubscriptions
         payment_intent = invoice[:payment_intent] if invoice[:payment_intent]
         refund = ::Stripe::Refund.create({ payment_intent: payment_intent })
       end
+
     end
   end
 end

--- a/assets/javascripts/discourse/components/modal/admin-cancel-subscription.gjs
+++ b/assets/javascripts/discourse/components/modal/admin-cancel-subscription.gjs
@@ -25,8 +25,12 @@ export default class AdminCancelSubscription extends Component {
           @label="yes_value"
           @action={{fn
             @model.cancelSubscription
-            (hash subscription=@model.subscription refund=this.refund closeModal=@closeModal)
-            }}
+            (hash
+              subscription=@model.subscription
+              refund=this.refund
+              closeModal=@closeModal
+            )
+          }}
           @icon="times"
           @isLoading={{@model.subscription.loading}}
           class="btn-danger"

--- a/assets/javascripts/discourse/components/modal/admin-cancel-subscription.gjs
+++ b/assets/javascripts/discourse/components/modal/admin-cancel-subscription.gjs
@@ -25,8 +25,8 @@ export default class AdminCancelSubscription extends Component {
           @label="yes_value"
           @action={{fn
             @model.cancelSubscription
-            (hash subscription=@model.subscription refund=this.refund)
-          }}
+            (hash subscription=@model.subscription refund=this.refund closeModal=@closeModal)
+            }}
           @icon="times"
           @isLoading={{@model.subscription.loading}}
           class="btn-danger"

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-subscriptions.js
@@ -40,6 +40,8 @@ export default Controller.extend({
   cancelSubscription(model) {
     const subscription = model.subscription;
     const refund = model.refund;
+    const closeModal = model.closeModal;
+
     subscription.set("loading", true);
     subscription
       .destroy(refund)
@@ -52,6 +54,7 @@ export default Controller.extend({
       )
       .finally(() => {
         subscription.set("loading", false);
+        closeModal();
       });
   },
 });

--- a/spec/requests/admin/subscriptions_controller_spec.rb
+++ b/spec/requests/admin/subscriptions_controller_spec.rb
@@ -77,18 +77,19 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
 
       it "deletes a customer" do
         ::Stripe::Subscription
-          .expects(:delete)
+          .expects(:cancel)
           .with("sub_12345")
           .returns(plan: { product: "pr_34578" }, customer: "c_123")
 
+        # We don't want to delete the customer record. The webhook hook will update the status instead.
         expect { delete "/s/admin/subscriptions/sub_12345.json" }.to change {
           DiscourseSubscriptions::Customer.count
-        }.by(-1)
+        }.by(0)
       end
 
       it "removes the user from the group" do
         ::Stripe::Subscription
-          .expects(:delete)
+          .expects(:cancel)
           .with("sub_12345")
           .returns(
             plan: {
@@ -107,7 +108,7 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
 
       it "does not remove the user from the group" do
         ::Stripe::Subscription
-          .expects(:delete)
+          .expects(:cancel)
           .with("sub_12345")
           .returns(
             plan: {
@@ -126,7 +127,7 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
 
       it "refunds if params[:refund] present" do
         ::Stripe::Subscription
-          .expects(:delete)
+          .expects(:cancel)
           .with("sub_12345")
           .returns(plan: { product: "pr_34578" }, customer: "c_123")
         ::Stripe::Subscription

--- a/spec/requests/admin/subscriptions_controller_spec.rb
+++ b/spec/requests/admin/subscriptions_controller_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe DiscourseSubscriptions::Admin::SubscriptionsController do
           .returns(plan: { product: "pr_34578" }, customer: "c_123")
 
         # We don't want to delete the customer record. The webhook hook will update the status instead.
-        expect { delete "/s/admin/subscriptions/sub_12345.json" }.to change {
+        expect { delete "/s/admin/subscriptions/sub_12345.json" }.not_to change {
           DiscourseSubscriptions::Customer.count
-        }.by(0)
+        }
       end
 
       it "removes the user from the group" do


### PR DESCRIPTION
Stripe at some point deprecated their `.delete` method on Subscription
in favor of `.cancel`. When we upgraded to latest stripe gem in dcde03d7c46661e447c22524ab376c95698b7517
this call likely stopped working.

In addition to this fix we are no longer deleting the customer record,
but instead of updating the status of it. This way an admin can easily
see 'active' as well as 'canceled' subscriptions. This behavior matches
what we are already doing for an individual user listing all of their
subscriptions.

Bug report: https://meta.discourse.org/t/316007
