### PR TITLE
FIX: Decimal point truncation

### DIFF
--- a/assets/javascripts/discourse/helpers/format-currency.js
+++ b/assets/javascripts/discourse/helpers/format-currency.js
@@ -1,40 +1,36 @@
-import Helper from "@ember/component/helper";
+import { helper } from '@ember/component/helper';
 
-export default Helper.helper(function (params) {
+export function formatCurrency([currency, amount]) {
   let currencySign;
 
-  switch (params[0]) {
+  switch (currency.toUpperCase()) {
     case "EUR":
-    case "eur":
       currencySign = "€";
       break;
     case "GBP":
-    case "gbp":
       currencySign = "£";
       break;
     case "INR":
-    case "inr":
       currencySign = "₹";
       break;
     case "BRL":
-    case "brl":
       currencySign = "R$";
       break;
     case "DKK":
-    case "dkk":
       currencySign = "DKK";
       break;
     case "SGD":
-    case "sgd":
       currencySign = "S$";
       break;
     case "ZAR":
-    case "zar":
       currencySign = "R";
       break;
     default:
       currencySign = "$";
   }
 
-  return currencySign + params[1];
-});
+  let formattedAmount = parseFloat(amount).toFixed(2);
+  return currencySign + formattedAmount;
+}
+
+export default helper(formatCurrency);

--- a/assets/javascripts/discourse/helpers/format-currency.js
+++ b/assets/javascripts/discourse/helpers/format-currency.js
@@ -1,4 +1,4 @@
-import { helper } from '@ember/component/helper';
+import { helper } from "@ember/component/helper";
 
 export function formatCurrency([currency, amount]) {
   let currencySign;

--- a/test/javascripts/helpers/format-currency-test.js
+++ b/test/javascripts/helpers/format-currency-test.js
@@ -1,12 +1,12 @@
-import { setupTest } from 'ember-qunit';
-import { module, test } from 'qunit';
-import { formatCurrency } from 'discourse/plugins/discourse-subscriptions/discourse/helpers/format-currency';
+import { setupTest } from "ember-qunit";
+import { module, test } from "qunit";
+import { formatCurrency } from "discourse/plugins/discourse-subscriptions/discourse/helpers/format-currency";
 
-module('Unit | Helper | format-currency', function(hooks) {
+module("Unit | Helper | format-currency", function (hooks) {
   setupTest(hooks);
 
-  test('it formats USD correctly', function(assert) {
+  test("it formats USD correctly", function (assert) {
     let result = formatCurrency(["USD", 338.2]);
-    assert.equal(result, '$338.20', 'Formats USD correctly');
+    assert.equal(result, "$338.20", "Formats USD correctly");
   });
 });

--- a/test/javascripts/helpers/format-currency-test.js
+++ b/test/javascripts/helpers/format-currency-test.js
@@ -9,4 +9,9 @@ module("Unit | Helper | format-currency", function (hooks) {
     let result = formatCurrency(["USD", 338.2]);
     assert.equal(result, "$338.20", "Formats USD correctly");
   });
+
+  test("it rounds correctly", function (assert) {
+    let result = formatCurrency(["USD", 338.289]);
+    assert.equal(result, "$338.29", "Rounds correctly");
+  });
 });

--- a/test/javascripts/helpers/format-currency-test.js
+++ b/test/javascripts/helpers/format-currency-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+import { formatCurrency } from 'discourse/plugins/discourse-subscriptions/discourse/helpers/format-currency';
+
+module('Unit | Helper | format-currency', function(hooks) {
+  setupTest(hooks);
+
+  test('it formats USD correctly', function(assert) {
+    let result = formatCurrency(["USD", 338.2]);
+    assert.equal(result, '$338.20', 'Formats USD correctly');
+  });
+});

--- a/test/javascripts/helpers/format-currency-test.js
+++ b/test/javascripts/helpers/format-currency-test.js
@@ -1,5 +1,5 @@
-import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
+import { module, test } from 'qunit';
 import { formatCurrency } from 'discourse/plugins/discourse-subscriptions/discourse/helpers/format-currency';
 
 module('Unit | Helper | format-currency', function(hooks) {


### PR DESCRIPTION
Amounts like $45.80 were being displayed as $45.8. Which doesn't look
correct for currency.

Bug Report: https://meta.discourse.org/t/316007
