### PR TITLE
FIX: Pricing table for one-off purchases

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -47,10 +47,7 @@ module DiscourseSubscriptions
         subscription = checkout_session[:subscription]
 
         if !subscription.nil?
-          Subscription.create(
-            customer_id: discourse_customer.id,
-            external_id: subscription,
-          )
+          Subscription.create(customer_id: discourse_customer.id, external_id: subscription)
         end
 
         line_items =

--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -29,7 +29,8 @@ module DiscourseSubscriptions
                 payments[:data].select { |payment| invoice_ids.include?(payment[:invoice]) }
 
               # Pricing table one-off purchases do not have invoices
-              payments_without_invoices = payments[:data].select { |payment| payment[:invoice].nil? }
+              payments_without_invoices =
+                payments[:data].select { |payment| payment[:invoice].nil? }
 
               data = data | payments_from_invoices | payments_without_invoices
             end

--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -27,7 +27,11 @@ module DiscourseSubscriptions
               payments = ::Stripe::PaymentIntent.list(customer: customer_id)
               payments_from_invoices =
                 payments[:data].select { |payment| invoice_ids.include?(payment[:invoice]) }
-              data = data | payments_from_invoices
+
+              # Pricing table one-off purchases do not have invoices
+              payments_without_invoices = payments[:data].select { |payment| payment[:invoice].nil? }
+
+              data = data | payments_from_invoices | payments_without_invoices
             end
           end
 
@@ -42,14 +46,13 @@ module DiscourseSubscriptions
       private
 
       def parse_invoices(all_invoices, product_ids)
-        invoices_with_products =
-          all_invoices[:data].select do |invoice|
-            invoice_lines = invoice[:lines][:data][0] if invoice[:lines] && invoice[:lines][:data]
-            if invoice_lines
-              invoice_product_id = parse_invoice_lines(invoice_lines)
-              product_ids.include?(invoice_product_id)
-            end
+        all_invoices[:data].select do |invoice|
+          invoice_lines = invoice[:lines][:data][0] if invoice[:lines] && invoice[:lines][:data]
+          if invoice_lines
+            invoice_product_id = parse_invoice_lines(invoice_lines)
+            product_ids.include?(invoice_product_id)
           end
+        end
       end
 
       def parse_invoice_lines(invoice_lines)

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -207,7 +207,10 @@ RSpec.describe DiscourseSubscriptions::HooksController do
 
     describe "checkout.session.completed for one-off purchase" do
       before do
-        event = { type: "checkout.session.completed", data: checkout_session_completed_data_one_off }
+        event = {
+          type: "checkout.session.completed",
+          data: checkout_session_completed_data_one_off,
+        }
         ::Stripe::Checkout::Session
           .stubs(:list_line_items)
           .with(checkout_session_completed_data[:object][:id], { limit: 1 })

--- a/spec/requests/user/payments_controller_spec.rb
+++ b/spec/requests/user/payments_controller_spec.rb
@@ -60,5 +60,29 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
       expect(invoice).to eq("inv_900007")
       expect(parsed_body.count).to eq(2)
     end
+
+    it "gets pricing table one-off purchases" do
+      ::Stripe::Invoice
+        .expects(:list)
+        .with(customer: "c_345678")
+        .returns(
+          data: [],
+        )
+
+      ::Stripe::PaymentIntent
+        .expects(:list)
+        .with(customer: "c_345678")
+        .returns(
+          data: [
+            { id: "pi_900010", invoice: nil, created: Time.now },
+          ],
+        )
+
+      get "/s/user/payments.json"
+
+      parsed_body = response.parsed_body
+
+      expect(parsed_body.count).to eq(1)
+    end
   end
 end

--- a/spec/requests/user/payments_controller_spec.rb
+++ b/spec/requests/user/payments_controller_spec.rb
@@ -62,21 +62,12 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
     end
 
     it "gets pricing table one-off purchases" do
-      ::Stripe::Invoice
-        .expects(:list)
-        .with(customer: "c_345678")
-        .returns(
-          data: [],
-        )
+      ::Stripe::Invoice.expects(:list).with(customer: "c_345678").returns(data: [])
 
       ::Stripe::PaymentIntent
         .expects(:list)
         .with(customer: "c_345678")
-        .returns(
-          data: [
-            { id: "pi_900010", invoice: nil, created: Time.now },
-          ],
-        )
+        .returns(data: [{ id: "pi_900010", invoice: nil, created: Time.now }])
 
       get "/s/user/payments.json"
 


### PR DESCRIPTION
When using the Stripe Pricing table for one-off purchases
(non-subscriptions) the webhook was encountering an error because it was
expecting subscription information which does not exist for one-off
purchases. This fix addresses that issue ensuring that no errors occur,
that users are added to the appropriate group, and that uses can see
their purchase on the billing page.
