### PR TITLE
DEV: Use warn instead of info for Rails logger

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -32,7 +32,7 @@ module DiscourseSubscriptions
         checkout_session = event[:data][:object]
 
         if SiteSetting.discourse_subscriptions_enable_verbose_logging
-          Rails.logger.info("checkout.session.completed data: #{checkout_session}")
+          Rails.logger.warn("checkout.session.completed data: #{checkout_session}")
         end
         email = checkout_session[:customer_email]
 
@@ -43,7 +43,7 @@ module DiscourseSubscriptions
         customer_id = checkout_session[:customer]
 
         if SiteSetting.discourse_subscriptions_enable_verbose_logging
-          Rails.logger.info("Looking up user with email: #{email}")
+          Rails.logger.warn("Looking up user with email: #{email}")
         end
 
         user = ::User.find_by_username_or_email(email)


### PR DESCRIPTION
Follow up to: e92dd399280b0170e118e126464b7f3051c953a6
