### PR TITLE
FIX: Create customer for one off pricing table purchases

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -40,9 +40,7 @@ module DiscourseSubscriptions
         return render_json_error "email not found" if !email
 
         if checkout_session[:customer].nil?
-          customer = ::Stripe::Customer.create({
-            email: email,
-          })
+          customer = ::Stripe::Customer.create({ email: email })
           customer_id = customer[:id]
         else
           customer_id = checkout_session[:customer]

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         object: {
           id: "cs_test_a1ENei5A9TGOaEketyV5qweiQR5CyJWHT5j8T3HheQY3uah3RxzKttVUKZ",
           object: "checkout.session",
-          customer: customer.customer_id,
+          customer: nil,
           customer_email: user.email,
           invoice: nil,
           metadata: {
@@ -110,7 +110,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           id: "cs_test_a1ENei5A9TGOaEketyV5qweiQR5CyJWHT5j8T3HheQY3uah3RxzKttVUKZ",
           object: "checkout.session",
           customer: nil,
-          customer_email: user.email,
+          customer_email: nil,
           invoice: "in_1P9b7iEYXaQnncSh81AQtuHD",
           metadata: {
           },
@@ -118,7 +118,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           payment_status: "paid",
           status: "complete",
           submit_type: nil,
-          subscription: "sub_1P9b7iEYXaQnncSh3H3G9d2Y",
+          subscription: nil,
           success_url: "http://localhost:4200/my/billing/subscriptions",
           url: nil,
         },
@@ -197,6 +197,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           .returns(list_line_items_data)
 
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
+        ::Stripe::Customer.stubs(:create).returns(id: "cus_1234")
       end
 
       it "is returns 422" do
@@ -217,6 +218,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           .returns(list_line_items_data)
 
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
+        ::Stripe::Customer.stubs(:create).returns(id: "cus_1234")
       end
 
       it "is returns 200" do
@@ -236,6 +238,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           .returns(list_line_items_data)
 
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
+        ::Stripe::Customer.stubs(:create).returns(id: "cus_1234")
       end
 
       it "is returns 422" do


### PR DESCRIPTION
When using the Stripe Pricing Table for one-off purchases
(non-subscription) stripe doesn't automatically create a customer
record. This was causing the pricing table webhook
endpoint to end prematurely and not add users to their appropriate
group after purchase. Now if we detect that there is no customer record
we will make an api call to Stripe to create one.
