### PR TITLE
FIX: Payments not showing up for users

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -57,9 +57,13 @@ module DiscourseSubscriptions
         discourse_customer = Customer.create(user_id: user.id, customer_id: customer_id)
 
         subscription = checkout_session[:subscription]
+        payment_intent_id = checkout_session[:payment_intent]
 
-        if !subscription.nil?
+        if subscription.present?
           Subscription.create(customer_id: discourse_customer.id, external_id: subscription)
+        elsif payment_intent_id
+          # Attach the payment intent to the customer for one-off purchases
+          ::Stripe::PaymentIntent.update(payment_intent_id, { customer: customer_id })
         end
 
         line_items =

--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -28,9 +28,17 @@ module DiscourseSubscriptions
               payments_from_invoices =
                 payments[:data].select { |payment| invoice_ids.include?(payment[:invoice]) }
 
+              if SiteSetting.discourse_subscriptions_enable_verbose_logging
+                Rails.logger.warn("Payments from invoices: #{payments_from_invoices}")
+              end
+
               # Pricing table one-off purchases do not have invoices
               payments_without_invoices =
                 payments[:data].select { |payment| payment[:invoice].nil? }
+
+              if SiteSetting.discourse_subscriptions_enable_verbose_logging
+                Rails.logger.warn("Payments without invoices: #{payments_without_invoices}")
+              end
 
               data = data | payments_from_invoices | payments_without_invoices
             end

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -221,7 +221,8 @@ RSpec.describe DiscourseSubscriptions::HooksController do
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
         ::Stripe::Customer.stubs(:create).returns(id: "cus_1234")
 
-        ::Stripe::PaymentIntent.expects(:update)
+        ::Stripe::PaymentIntent
+          .expects(:update)
           .with("pi_3PsohkGHcn71qeAp06trzhx7", { customer: "cus_1234" })
           .returns({ id: "pi_3PsohkGHcn" })
       end

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -94,6 +94,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
           metadata: {
           },
           mode: "subscription",
+          payment_intent: "pi_3PsohkGHcn",
           payment_status: "paid",
           status: "complete",
           submit_type: nil,
@@ -219,6 +220,10 @@ RSpec.describe DiscourseSubscriptions::HooksController do
 
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
         ::Stripe::Customer.stubs(:create).returns(id: "cus_1234")
+
+        ::Stripe::PaymentIntent.expects(:update)
+          .with("pi_3PsohkGHcn71qeAp06trzhx7", { customer: "cus_1234" })
+          .returns({ id: "pi_3PsohkGHcn" })
       end
 
       it "is returns 200" do

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe DiscourseSubscriptions::HooksController do
 
         ::Stripe::PaymentIntent
           .expects(:update)
-          .with("pi_3PsohkGHcn71qeAp06trzhx7", { customer: "cus_1234" })
+          .with("pi_3PsohkGHcn", { customer: "cus_1234" })
           .returns({ id: "pi_3PsohkGHcn" })
       end
 


### PR DESCRIPTION
Pricing table payments for one off purchases need to be attached to the
customer or they don't show up on the user's billing payments page.
