### PR TITLE
DEV: Fetch related guest payments

### DIFF
--- a/app/controllers/discourse_subscriptions/hooks_controller.rb
+++ b/app/controllers/discourse_subscriptions/hooks_controller.rb
@@ -57,13 +57,9 @@ module DiscourseSubscriptions
         discourse_customer = Customer.create(user_id: user.id, customer_id: customer_id)
 
         subscription = checkout_session[:subscription]
-        payment_intent_id = checkout_session[:payment_intent]
 
         if subscription.present?
           Subscription.create(customer_id: discourse_customer.id, external_id: subscription)
-        elsif payment_intent_id
-          # Attach the payment intent to the customer for one-off purchases
-          ::Stripe::PaymentIntent.update(payment_intent_id, { customer: customer_id })
         end
 
         line_items =

--- a/app/controllers/discourse_subscriptions/user/payments_controller.rb
+++ b/app/controllers/discourse_subscriptions/user/payments_controller.rb
@@ -87,11 +87,12 @@ module DiscourseSubscriptions
         begin
           loop do
             # Fetch charges in batches of 100, using pagination with starting_after
-            charges = ::Stripe::Charge.list(
-              limit: 100,
-              starting_after: starting_after,
-              expand: ['data.payment_intent']
-            )
+            charges =
+              ::Stripe::Charge.list(
+                limit: 100,
+                starting_after: starting_after,
+                expand: ["data.payment_intent"],
+              )
 
             charges[:data].each do |charge|
               # Check if the charge is associated with the given email and has no customer ID

--- a/spec/requests/hooks_controller_spec.rb
+++ b/spec/requests/hooks_controller_spec.rb
@@ -220,11 +220,6 @@ RSpec.describe DiscourseSubscriptions::HooksController do
 
         ::Stripe::Webhook.stubs(:construct_event).returns(event)
         ::Stripe::Customer.stubs(:create).returns(id: "cus_1234")
-
-        ::Stripe::PaymentIntent
-          .expects(:update)
-          .with("pi_3PsohkGHcn", { customer: "cus_1234" })
-          .returns({ id: "pi_3PsohkGHcn" })
       end
 
       it "is returns 200" do

--- a/spec/requests/user/payments_controller_spec.rb
+++ b/spec/requests/user/payments_controller_spec.rb
@@ -87,37 +87,43 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
 
       ::Stripe::Charge
         .expects(:list)
-        .with(limit: 100, starting_after: nil, expand: ['data.payment_intent'])
+        .with(limit: 100, starting_after: nil, expand: ["data.payment_intent"])
         .returns(
           data: [
             {
               id: "ch_1HtGz2GHcn71qeAp4YjA2oB4",
               amount: 2000,
               currency: "usd",
-              billing_details: { email: "asdf@example.com" },
+              billing_details: {
+                email: "asdf@example.com",
+              },
               customer: nil, # guest payment
               payment_intent: "pi_1HtGz1GHcn71qeApT9N2Cjln",
-              created: Time.now.to_i
+              created: Time.now.to_i,
             },
             {
               id: "ch_2HtGz2GHcn71qeAp4YjA2oB4",
               amount: 2000,
               currency: "usd",
-              billing_details: { email: "zxcv@example.com" },
+              billing_details: {
+                email: "zxcv@example.com",
+              },
               customer: nil, # different guest
               payment_intent: "pi_2HtGz1GHcn71qeApT9N2Cjln",
-              created: Time.now.to_i
+              created: Time.now.to_i,
             },
             {
               id: "ch_1HtGz3GHcn71qeAp5YjA2oC5",
               amount: 3000,
               currency: "usd",
-              billing_details: { email: "fdsa@example.com" },
+              billing_details: {
+                email: "fdsa@example.com",
+              },
               customer: "cus_1234", # This is not a guest payment
               payment_intent: "pi_3HtGz2GHcn71qeApT9N2Cjln",
-              created: Time.now.to_i
-            }
-          ]
+              created: Time.now.to_i,
+            },
+          ],
         )
 
       get "/s/user/payments.json"

--- a/spec/requests/user/payments_controller_spec.rb
+++ b/spec/requests/user/payments_controller_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
               amount: 2000,
               currency: "usd",
               billing_details: {
-                email: "asdf@example.com",
+                email: user.email,
               },
               customer: nil, # guest payment
               payment_intent: "pi_1HtGz1GHcn71qeApT9N2Cjln",
@@ -131,9 +131,9 @@ RSpec.describe DiscourseSubscriptions::User::PaymentsController do
       parsed_body = response.parsed_body
 
       # Validate that only guest payments with the specified email are returned
-      expect(parsed_body.count).to eq(1)
-      # expect(parsed_body.first["id"]).to eq("ch_1HtGz2GHcn71qeAp4YjA2oB4")
-      # expect(parsed_body.first["customer"]).to be_nil
+      expect(parsed_body.count).to eq(2)
+      expect(parsed_body.first["id"]).to eq("ch_1HtGz2GHcn71qeAp4YjA2oB4")
+      expect(parsed_body.first["customer"]).to be_nil
     end
   end
 end


### PR DESCRIPTION
This change partly reverts 700c5e772743dc8c1f648ad8b6bf42018ef938cb

because of this Stripe error:

> Unexpected error: Some of the parameters you provided (customer) cannot be used when modifying a PaymentIntent that was created by Checkout. You can try again without those parameters.

Apparently we can't use PaymentIntent api for our use case. This commit
provides a work around there where we instead fetch the guest payments
if the pricing table is being used so that they show up on the user's
  billing payments page.
