### PR TITLE
FIX: Redirect to the pricing table page when enabled

### DIFF
--- a/assets/javascripts/discourse/routes/subscribe.js
+++ b/assets/javascripts/discourse/routes/subscribe.js
@@ -1,14 +1,15 @@
-import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class SubscribeRoute extends Route {
   @service router;
 
   beforeModel() {
-    const pricingTableEnabled = this.siteSettings.discourse_subscriptions_pricing_table_enabled;
+    const pricingTableEnabled =
+      this.siteSettings.discourse_subscriptions_pricing_table_enabled;
 
     if (pricingTableEnabled) {
-      this.router.transitionTo('subscriptions');
+      this.router.transitionTo("subscriptions");
     }
   }
 }

--- a/assets/javascripts/discourse/routes/subscribe.js
+++ b/assets/javascripts/discourse/routes/subscribe.js
@@ -1,5 +1,5 @@
 import Route from "@ember/routing/route";
-import { inject as service } from "@ember/service";
+import { service } from "@ember/service";
 
 export default class SubscribeRoute extends Route {
   @service router;

--- a/assets/javascripts/discourse/routes/subscribe.js
+++ b/assets/javascripts/discourse/routes/subscribe.js
@@ -3,6 +3,7 @@ import { service } from "@ember/service";
 
 export default class SubscribeRoute extends Route {
   @service router;
+  @service siteSettings;
 
   beforeModel() {
     const pricingTableEnabled =

--- a/assets/javascripts/discourse/routes/subscriptions.js
+++ b/assets/javascripts/discourse/routes/subscriptions.js
@@ -1,14 +1,14 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 
-export default class SubscribeRoute extends Route {
+export default class SubscriptionsRoute extends Route {
   @service router;
 
   beforeModel() {
     const pricingTableEnabled = this.siteSettings.discourse_subscriptions_pricing_table_enabled;
 
-    if (pricingTableEnabled) {
-      this.router.transitionTo('subscriptions');
+    if (!pricingTableEnabled) {
+      this.router.transitionTo('subscribe');
     }
   }
 }

--- a/assets/javascripts/discourse/routes/subscriptions.js
+++ b/assets/javascripts/discourse/routes/subscriptions.js
@@ -3,6 +3,7 @@ import { service } from "@ember/service";
 
 export default class SubscriptionsRoute extends Route {
   @service router;
+  @service siteSettings;
 
   beforeModel() {
     const pricingTableEnabled =

--- a/assets/javascripts/discourse/routes/subscriptions.js
+++ b/assets/javascripts/discourse/routes/subscriptions.js
@@ -1,14 +1,15 @@
-import Route from '@ember/routing/route';
-import { inject as service } from '@ember/service';
+import Route from "@ember/routing/route";
+import { inject as service } from "@ember/service";
 
 export default class SubscriptionsRoute extends Route {
   @service router;
 
   beforeModel() {
-    const pricingTableEnabled = this.siteSettings.discourse_subscriptions_pricing_table_enabled;
+    const pricingTableEnabled =
+      this.siteSettings.discourse_subscriptions_pricing_table_enabled;
 
     if (!pricingTableEnabled) {
-      this.router.transitionTo('subscribe');
+      this.router.transitionTo("subscribe");
     }
   }
 }

--- a/assets/javascripts/discourse/routes/subscriptions.js
+++ b/assets/javascripts/discourse/routes/subscriptions.js
@@ -1,5 +1,5 @@
 import Route from "@ember/routing/route";
-import { inject as service } from "@ember/service";
+import { service } from "@ember/service";
 
 export default class SubscriptionsRoute extends Route {
   @service router;

--- a/spec/system/pricing_table_spec.rb
+++ b/spec/system/pricing_table_spec.rb
@@ -107,9 +107,7 @@ RSpec.describe "Pricing Table", type: :system, js: true do
     sign_in(admin)
     visit("/s")
 
-    try_until_success do
-      expect(current_url).to match("/s/subscriptions")
-    end
+    try_until_success { expect(current_url).to match("/s/subscriptions") }
   end
 
   it "Redirects to /s if pricing table is not enabled" do
@@ -117,8 +115,6 @@ RSpec.describe "Pricing Table", type: :system, js: true do
     SiteSetting.discourse_subscriptions_campaign_enabled = false
     visit("/s/subscriptions")
 
-    try_until_success do
-      expect(current_url).to match("/s")
-    end
+    try_until_success { expect(current_url).to match("/s") }
   end
 end

--- a/spec/system/pricing_table_spec.rb
+++ b/spec/system/pricing_table_spec.rb
@@ -102,4 +102,23 @@ RSpec.describe "Pricing Table", type: :system, js: true do
       text: "Log in or create an account to subscribe.",
     )
   end
+
+  it "Redirects to the pricing table page if enabled" do
+    sign_in(admin)
+    visit("/s")
+
+    try_until_success do
+      expect(current_url).to match("/s/subscriptions")
+    end
+  end
+
+  it "Redirects to /s if pricing table is not enabled" do
+    sign_in(admin)
+    SiteSetting.discourse_subscriptions_campaign_enabled = false
+    visit("/s/subscriptions")
+
+    try_until_success do
+      expect(current_url).to match("/s")
+    end
+  end
 end


### PR DESCRIPTION
If the pricing table is enabled the `/s` route should redirect to the
pricing table route and vice versa.
