### PR TITLE
DEV: Update more deprecated Font Awesome icon names

### DIFF
--- a/assets/javascripts/discourse/components/campaign-banner.hbs
+++ b/assets/javascripts/discourse/components/campaign-banner.hbs
@@ -3,7 +3,7 @@
     class="campaign-banner"
     style={{html-safe (concat "box-shadow: 5px 5px #" this.dropShadowColor)}}
   >
-    <DButton @icon="times" @action={{this.dismissBanner}} class="close" />
+    <DButton @icon="xmark" @action={{this.dismissBanner}} class="close" />
 
     <div class="campaign-banner-info" style={{html-safe this.bannerInfoStyle}}>
       {{#if this.isGoalMet}}

--- a/assets/javascripts/discourse/components/create-coupon-form.hbs
+++ b/assets/javascripts/discourse/components/create-coupon-form.hbs
@@ -44,7 +44,7 @@
     @action={{action "cancelCreate"}}
     label="cancel"
     @title="cancel"
-    @icon="times"
+    @icon="xmark"
     class="btn btn-icon"
   />
 </div>

--- a/assets/javascripts/discourse/components/modal/admin-cancel-subscription.gjs
+++ b/assets/javascripts/discourse/components/modal/admin-cancel-subscription.gjs
@@ -31,7 +31,7 @@ export default class AdminCancelSubscription extends Component {
               closeModal=@closeModal
             )
           }}
-          @icon="times"
+          @icon="xmark"
           @isLoading={{@model.subscription.loading}}
           class="btn-danger"
         />

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-coupons.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-coupons.hbs
@@ -32,7 +32,7 @@
               <DButton
                 @action={{action "deleteCoupon"}}
                 @actionParam={{coupon}}
-                @icon="trash-alt"
+                @icon="trash-can"
                 class="btn-danger btn btn-icon btn-no-text"
               />
             </td>

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-plans-index.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-plans-index.hbs
@@ -16,13 +16,13 @@
         <td class="td-right">
           <DButton
             @action={{action "editPlan" plan.id}}
-            @icon="far-edit"
+            @icon="far-pen-to-square"
             class="btn no-text btn-icon"
           />
           <DButton
             @action={{route-action "destroyPlan"}}
             @actionParam={{plan}}
-            @icon="trash-alt"
+            @icon="trash-can"
             class="btn-danger btn no-text btn-icon"
           />
         </td>

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-index.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-index.hbs
@@ -57,7 +57,7 @@
                 <DButton
                   @action={{route-action "destroyProduct"}}
                   @actionParam={{product}}
-                  @icon="trash-alt"
+                  @icon="trash-can"
                   class="btn-danger btn no-text btn-icon"
                 />
               </div>

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-products-show.hbs
@@ -139,7 +139,7 @@
 {{/unless}}
 
 <div class="pull-right">
-  <DButton @label="cancel" @action={{action "cancelProduct"}} @icon="times" />
+  <DButton @label="cancel" @action={{action "cancelProduct"}} @icon="xmark" />
 
   {{#if this.model.product.isNew}}
     <DButton

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions-subscriptions.hbs
@@ -76,7 +76,7 @@
                   @disabled={{subscription.canceled}}
                   @label="cancel"
                   @action={{action "showCancelModal" subscription}}
-                  @icon="times"
+                  @icon="xmark"
                 />
               {{/if}}
             </td>

--- a/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions.hbs
+++ b/assets/javascripts/discourse/templates/admin/plugins-discourse-subscriptions.hbs
@@ -8,14 +8,14 @@
     {{#if this.campaignEnabled}}
       <DButton
         @label="discourse_subscriptions.campaign.refresh_campaign"
-        @icon="sync-alt"
+        @icon="rotate"
         @action={{action "triggerManualRefresh"}}
       />
     {{else}}
       {{#unless this.campaignProductSet}}
         <DButton
           @label="discourse_subscriptions.campaign.one_click_campaign"
-          @icon="plus-square"
+          @icon="square-plus"
           @action={{action "createOneClickCampaign"}}
           @isLoading={{this.loading}}
         />

--- a/assets/javascripts/discourse/templates/user/billing/subscriptions/index.hbs
+++ b/assets/javascripts/discourse/templates/user/billing/subscriptions/index.hbs
@@ -32,12 +32,12 @@
               {{else}}
                 <DButton
                   @action={{route-action "updateCard" subscription.id}}
-                  @icon="far-edit"
+                  @icon="far-pen-to-square"
                   class="btn no-text btn-icon"
                 />
                 <DButton
                   class="btn-danger btn no-text btn-icon"
-                  @icon="trash-alt"
+                  @icon="trash-can"
                   @disabled={{subscription.canceled_at}}
                   @action={{route-action "cancelSubscription" subscription}}
                 />


### PR DESCRIPTION
This PR updates more deprecated Font Awesome icon names. For more detail, refer to the announcement at https://meta.discourse.org/t/-/325349.