### PR TITLE
FEATURE: Add support for CHF currency

### DIFF
--- a/app/serializers/discourse_subscriptions/payment_serializer.rb
+++ b/app/serializers/discourse_subscriptions/payment_serializer.rb
@@ -53,6 +53,8 @@ module DiscourseSubscriptions
         "S$"
       when "zar"
         "R"
+      when "chf"
+        "CHF"
       else
         "$"
       end

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-products-show-plans-show.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-subscriptions-products-show-plans-show.js
@@ -43,6 +43,7 @@ export default class AdminPluginsDiscourseSubscriptionsProductsShowPlansShowCont
       { id: "SGD", name: "SGD" },
       { id: "JPY", name: "JPY" },
       { id: "ZAR", name: "ZAR" },
+      { id: "CHF", name: "CHF" },
     ];
   }
 

--- a/assets/javascripts/discourse/helpers/format-currency.js
+++ b/assets/javascripts/discourse/helpers/format-currency.js
@@ -25,6 +25,9 @@ export function formatCurrency([currency, amount]) {
     case "ZAR":
       currencySign = "R";
       break;
+    case "CHF":
+      currencySign = "CHF";
+      break;
     default:
       currencySign = "$";
   }

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -35,6 +35,7 @@ discourse_subscriptions:
       - DKK
       - SGD
       - ZAR
+      - CHF
   discourse_subscriptions_campaign_enabled:
     client: true
     default: false


### PR DESCRIPTION
Stripe supports the Swiss Franc so we can add support for it.

https://meta.discourse.org/t/316003
