### PR TITLE
UX: Campaign banner layout improvements

### DIFF
--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -106,7 +106,7 @@ body.archetype-regular {
   box-shadow: 5px 5px
     var(--discourse_subscriptions_campaign_banner_shadow_color);
 
-  @media screen and (max-width: 400px) {
+  @media screen and (max-width: 700px) {
     width: 98%;
     flex-direction: column;
   }
@@ -131,7 +131,7 @@ body.archetype-regular {
     padding: 2em;
     background-color: var(--primary-very-low);
 
-    @media screen and (max-width: 400px) {
+    @media screen and (max-width: 700px) {
       width: calc(100% - 4em);
       display: flex;
       flex-direction: column;
@@ -161,7 +161,7 @@ body.archetype-regular {
         font-size: $font-down-1;
       }
 
-      @media screen and (max-width: 400px) {
+      @media screen and (max-width: 700px) {
         text-align: center;
       }
     }
@@ -197,7 +197,7 @@ body.archetype-regular {
     flex-flow: column;
     justify-content: center;
 
-    @media screen and (max-width: 400px) {
+    @media screen and (max-width: 700px) {
       width: calc(100% - 4em);
     }
 
@@ -283,44 +283,23 @@ html:not(.mobile-view) {
   }
 }
 
+// Stack buttons and container on mobile
+html.mobile-view #topic-footer-buttons {
+  display: flex;
+  flex-direction: column;
+}
+
 // Topic Footer Version
 html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
   margin-top: 2em;
-  height: min-content;
-  width: calc(100% + 14em);
+
+  @media screen and (min-width: 1000px) {
+    width: calc(var(--d-max-width) * .87);
+  }
 
   .btn.close {
     top: 1em;
     right: 1em;
-  }
-
-  .campaign-banner-info {
-    width: 65%;
-
-    &-header {
-      font-size: $font-up-6;
-    }
-
-    &-description {
-      font-size: $font-down-1;
-      margin: 0.25em 0.25em 1em 0 !important;
-    }
-  }
-
-  .campaign-banner-progress {
-    padding: 1.5em 2.5em 1em;
-
-    progress[value] {
-      height: 2em;
-    }
-
-    .campaign-banner-progress-users {
-      margin-top: 1em;
-    }
-
-    .campaign-banner-progress-users-title {
-      margin: 0;
-    }
   }
 }
 

--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -106,7 +106,7 @@ body.archetype-regular {
   box-shadow: 5px 5px
     var(--discourse_subscriptions_campaign_banner_shadow_color);
 
-  @media screen and (max-width: 700px) {
+  @include breakpoint(tablet) {
     width: 98%;
     flex-direction: column;
   }
@@ -131,7 +131,7 @@ body.archetype-regular {
     padding: 2em;
     background-color: var(--primary-very-low);
 
-    @media screen and (max-width: 700px) {
+    @include breakpoint(tablet) {
       width: calc(100% - 4em);
       display: flex;
       flex-direction: column;
@@ -143,7 +143,7 @@ body.archetype-regular {
       font-size: $font-up-4;
       margin: 0;
 
-      @media screen and (max-width: 750px) {
+      @include breakpoint(tablet) {
         font-size: $font-up-3;
       }
     }
@@ -157,11 +157,8 @@ body.archetype-regular {
       width: 100%;
       margin: 0.25em 0 1em 0;
 
-      @media screen and (max-width: 750px) {
+      @include breakpoint(tablet) {
         font-size: $font-down-1;
-      }
-
-      @media screen and (max-width: 700px) {
         text-align: center;
       }
     }
@@ -197,7 +194,7 @@ body.archetype-regular {
     flex-flow: column;
     justify-content: center;
 
-    @media screen and (max-width: 700px) {
+    @include breakpoint(tablet) {
       width: calc(100% - 4em);
     }
 
@@ -292,9 +289,10 @@ html.mobile-view #topic-footer-buttons {
 // Topic Footer Version
 html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
   margin-top: 2em;
+  width: calc(var(--d-max-width) * 0.87);
 
-  @media screen and (min-width: 1000px) {
-    width: calc(var(--d-max-width) * 0.87);
+  @include breakpoint(large) {
+    width: auto;
   }
 
   .btn.close {

--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -294,7 +294,7 @@ html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
   margin-top: 2em;
 
   @media screen and (min-width: 1000px) {
-    width: calc(var(--d-max-width) * .87);
+    width: calc(var(--d-max-width) * 0.87);
   }
 
   .btn.close {


### PR DESCRIPTION
This PR makes a few styling tweaks to the campaign banner:
* Increases breakpoint at which the banner layout stacks into a column
* Remove styling when banner is in topic footer for consistency between placement
* Stack banner underneath topic footer buttons when on mobile

## Before
<img width="542" alt="Screenshot 2025-04-10 at 10 37 08 AM" src="https://github.com/user-attachments/assets/707ae156-fa78-4a10-a2f0-a49941789b23" />

## After
<img width="542" alt="Screenshot 2025-04-10 at 10 47 50 AM" src="https://github.com/user-attachments/assets/b8b11ba2-7a02-4b6a-b827-69cd0c18547d" />

### Banner breakpoint styling
#### above-main-container
https://github.com/user-attachments/assets/167b3d71-8a2d-495e-b574-8be1f617d9b5

#### after-topic-footer-buttons
https://github.com/user-attachments/assets/3e14cf3b-ccdc-4391-8cf9-825c8a4d2062


