### PR TITLE
FIX: Campaign banner size when sidebar is active

### DIFF
--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -301,6 +301,13 @@ html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
   }
 }
 
+// Topic Footer Version + Sidebar visible
+html:not(.mobile-view) body.has-sidebar-page .subscriptions-campaign-topic-footer .campaign-banner {
+  @media screen and (max-width: 1285px) {
+    width: auto;
+  }
+}
+
 // CSS Animations for campaign Success
 @keyframes gradient {
   0% {

--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -302,11 +302,11 @@ html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
 }
 
 // Topic Footer Version + Sidebar visible
-html:not(.mobile-view)
-  body.has-sidebar-page
-  .subscriptions-campaign-topic-footer
-  .campaign-banner {
-  @media screen and (max-width: 1285px) {
+@media screen and (max-width: 1285px) {
+  html:not(.mobile-view)
+    body.has-sidebar-page
+    .subscriptions-campaign-topic-footer
+    .campaign-banner {
     width: auto;
   }
 }

--- a/assets/stylesheets/common/campaign.scss
+++ b/assets/stylesheets/common/campaign.scss
@@ -302,7 +302,10 @@ html:not(.mobile-view) .subscriptions-campaign-topic-footer .campaign-banner {
 }
 
 // Topic Footer Version + Sidebar visible
-html:not(.mobile-view) body.has-sidebar-page .subscriptions-campaign-topic-footer .campaign-banner {
+html:not(.mobile-view)
+  body.has-sidebar-page
+  .subscriptions-campaign-topic-footer
+  .campaign-banner {
   @media screen and (max-width: 1285px) {
     width: auto;
   }


### PR DESCRIPTION
This PR ensures the campaign banner in the topic footer resizes correctly when the sidebar is present.

## Before
https://github.com/user-attachments/assets/5c584c12-a0c0-46ec-aa56-7b9f5aa21e91

## After
https://github.com/user-attachments/assets/e36ad5a4-2cc2-4102-bc93-93f3a08e1c2a

